### PR TITLE
make sure that link to EESSI/cvmfs-layer repo is clickable + use lowercase

### DIFF
--- a/docs/11_cvmfs.md
+++ b/docs/11_cvmfs.md
@@ -9,4 +9,5 @@ The hierarchical structure with multiple caching layers (Stratum-0, Stratum-1's 
 
 For a (basic) introduction to CernVM-FS, see [this presentation](https://www.youtube.com/watch?v=MyYx-xaL36k).
 
-Detailed information about how we configure CVMFS is available at https://github.com/EESSI/CVMFS-layer.
+Detailed information about how we configure CVMFS is available at
+[https://github.com/EESSI/cvmfs-layer](https://github.com/EESSI/cvmfs-layer) .


### PR DESCRIPTION
link shown at https://eessi.github.io/docs/11_cvmfs/ is not clickable now, apparently `mkdocs` doesn't do that automatically for URLs