### PR TITLE
Drop navigation tabs on top

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,11 +7,8 @@ theme:
   name: material
   features:
     - instant
-    - tabs
   logo: img/logos/EESSI.png
   favicon: img/logos/EESSI.png
-  feature:
-    tabs: false
 repo_name: EESSI @ GitHub
 repo_url: https://github.com/EESSI
 edit_uri: docs/edit/master/docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,8 @@ theme:
     - tabs
   logo: img/logos/EESSI.png
   favicon: img/logos/EESSI.png
+  feature:
+    tabs: false
 repo_name: EESSI @ GitHub
 repo_url: https://github.com/EESSI
 edit_uri: docs/edit/master/docs


### PR DESCRIPTION
Fixes #28 
If we only have a `Home` tab then that is pretty useless