### PR TITLE
prefer using Singularity's support for scratch directories over bind mounting for /var/lib/cvmfs and /var/run/cvmfs

### DIFF
--- a/docs/pilot.md
+++ b/docs/pilot.md
@@ -34,10 +34,10 @@ The container image can be used directly by Singularity (no prior download requi
   ```
   These provides space for the CernVM-FS cache, and an empty home directory to use in the container.
 
-* Set the `$SINGULARITY_BIND` and `$SINGULARITY_HOME` environment variables to configure Singularity:
+* Set the `$SINGULARITY_HOME` and `SINGULARITY_SCRATCH` environment variables to configure Singularity:
   ```shell
-  export SINGULARITY_BIND="/tmp/$USER/var-run-cvmfs:/var/run/cvmfs,/tmp/$USER/var-lib-cvmfs:/var/lib/cvmfs"
   export SINGULARITY_HOME="/tmp/$USER/home:/home/$USER"
+  export SINGULARITY_SCRATCH="/var/lib/cvmfs,/var/run/cvmfs"
   ```
 
 * Start the container using `singularity shell`, using `--fusemount` to mount the EESSI config and pilot repositories


### PR DESCRIPTION
It turns out that bind mounting `/var/lib/cvmfs` and `/var/run/cvmfs` to temporary directories can lead to problems in some situations, leading to "`Failed to initialize loader socket`" errors when mounting the `/cvmfs` repositories.

This has proven to be an issue in multiple different situations:

* When using a temporary directory on a shared filesystem rather than using `/tmp` (encountered by @trz42)
* When running MPI software (encountered by @ocaisa, see https://github.com/EESSI/filesystem-layer/issues/38)

Using the support that Singularity has for scratch directories (`singularity --scratch` or equivalently `$SINGULARITY_SCRATCH`) circumvents these issues.