### PR TITLE
Add mkdocs-toc-sidebar-plugin to test.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: install mkdocs
       run: |
-          pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin
+          pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-toc-sidebar-plugin
           mkdocs --version
 
     - name: build tutorial

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: install mkdocs
       run: |
-          pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin
+          pip install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-toc-sidebar-plugin
           mkdocs --version
 
     - name: build tutorial


### PR DESCRIPTION
In the documentation there is 
```
markdown_extensions:
   - toc:
      permalink: true
```
But the final documentation has no table of contents. This is due to the lack of the
```
mkdocs-toc-sidebar-plugin
```
python package.