### PR TITLE
Change URL to 6th Easybuild User Meeting

### DIFF
--- a/talks/20210126_6th_EUM/README.md
+++ b/talks/20210126_6th_EUM/README.md
@@ -2,7 +2,7 @@
 
 talk by Bob Dröge (@bedroge) at the 6th EasyBuild User Meeting.
 
-https://easybuild.io/eum/
+https://easybuild.io/eum21/
 
 * [slides](EESSI-EUM21-20210126.pdf)
 * [recording (YouTube)](https://www.youtube.com/watch?v=1CXwzIW_MsU)


### PR DESCRIPTION
This just makes sure that the link to the EUM should keep working.