### PR TITLE
update mkdocs.yml as required by latest MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,9 @@
 site_name: "European Environment for Scientific Software Installations (EESSI)"
 site_url: https://eessi.github.io/docs/
-google_analytics:
-    - UA-169665333-1
-    - auto
+extra:
+  analytics:
+    provider: google
+    property: UA-169665333-1
 theme:
   name: material
   features:


### PR DESCRIPTION
fix for failing CI:
```
WARNING  -  Config value: 'google_analytics'. Warning: The configuration option google_analytics has been deprecated and will be removed in a future release of MkDocs. See the options available on your theme for an alternative.
Aborted with 1 Configuration Warnings in 'strict' mode!
```