### PR TITLE
Remove references to EESSI config repo from docs

### DIFF
--- a/docs/pilot.md
+++ b/docs/pilot.md
@@ -39,21 +39,18 @@ The container image can be used directly by Singularity (no prior download requi
   export SINGULARITY_HOME="/tmp/$USER/home:/home/$USER"
   ```
 
-* Start the container using `singularity shell`, using `--fusemount` to mount the EESSI config and pilot repositories
+* Start the container using `singularity shell`, using `--fusemount` to mount the EESSI pilot repository
   (using the `cvmfs2` command that is included in the container image):
   ```shell
-  export EESSI_CONFIG="container:cvmfs2 cvmfs-config.eessi-hpc.org /cvmfs/cvmfs-config.eessi-hpc.org"
   export EESSI_PILOT="container:cvmfs2 pilot.eessi-hpc.org /cvmfs/pilot.eessi-hpc.org"
-  singularity shell --fusemount "$EESSI_CONFIG" --fusemount "$EESSI_PILOT" docker://ghcr.io/eessi/client-pilot:centos7
+  singularity shell --fusemount "$EESSI_PILOT" docker://ghcr.io/eessi/client-pilot:centos7
   ```
 
- * This should give you a shell in the container, where the EESSI config and pilot repositories are mounted:
+ * This should give you a shell in the container, where the EESSI pilot repository is mounted:
    ```
-   $ singularity shell --fusemount "$EESSI_CONFIG" --fusemount "$EESSI_PILOT" docker://ghcr.io/eessi/client-pilot:centos7
+   $ singularity shell --fusemount "$EESSI_PILOT" docker://ghcr.io/eessi/client-pilot:centos7
    INFO:    Using cached SIF image
    CernVM-FS: pre-mounted on file descriptor 3
-   CernVM-FS: pre-mounted on file descriptor 3
-   CernVM-FS: loading Fuse module... done
    CernVM-FS: loading Fuse module... done
    Singularity>
    ```

--- a/docs/software_layer/build_nodes.md
+++ b/docs/software_layer/build_nodes.md
@@ -55,7 +55,7 @@ export EESSI_TMPDIR=/srt/$USER/EESSI
 mkdir -p $EESSI_TMPDIR
 mkdir /srt/tmp
 export SINGULARITY_BIND="$EESSI_TMPDIR/var-run-cvmfs:/var/run/cvmfs,$EESSI_TMPDIR/var-lib-cvmfs:/var/lib/cvmfs,/srt/tmp:/tmp"
-singularity shell -B /srt --fusemount "$EESSI_CONFIG" --fusemount "$EESSI_PILOT_READONLY" --fusemount "$EESSI_PILOT_WRITABLE_OVERLAY" docker://ghcr.io/eessi/build-node:debian10
+singularity shell -B /srt --fusemount "$EESSI_PILOT_READONLY" --fusemount "$EESSI_PILOT_WRITABLE_OVERLAY" docker://ghcr.io/eessi/build-node:debian10
 ```
 
 We will assume that `/tmp/$USER/EESSI` meets these requirements:
@@ -83,7 +83,6 @@ export SINGULARITY_HOME="$EESSI_TMPDIR/home:/home/$USER"
 Define values to pass to ``--fusemount` in ``singularity`` command:
 
 ```shell
-export EESSI_CONFIG="container:cvmfs2 cvmfs-config.eessi-hpc.org /cvmfs/cvmfs-config.eessi-hpc.org"
 export EESSI_PILOT_READONLY="container:cvmfs2 pilot.eessi-hpc.org /cvmfs_ro/pilot.eessi-hpc.org"
 export EESSI_PILOT_WRITABLE_OVERLAY="container:fuse-overlayfs -o lowerdir=/cvmfs_ro/pilot.eessi-hpc.org -o upperdir=$EESSI_TMPDIR/overlay-upper -o workdir=$EESSI_TMPDIR/overlay-work /cvmfs/pilot.eessi-hpc.org"
 ```
@@ -92,7 +91,7 @@ Start the container (which includes Debian 10, [CernVM-FS](https://cernvm.cern.c
 [fuse-overlayfs](https://github.com/containers/fuse-overlayfs)):
 
 ```shell
-singularity shell --fusemount "$EESSI_CONFIG" --fusemount "$EESSI_PILOT_READONLY" --fusemount "$EESSI_PILOT_WRITABLE_OVERLAY" docker://ghcr.io/eessi/build-node:debian10
+singularity shell --fusemount "$EESSI_PILOT_READONLY" --fusemount "$EESSI_PILOT_WRITABLE_OVERLAY" docker://ghcr.io/eessi/build-node:debian10
 ```
 
 Once the container image has been downloaded and converted to a Singularity image (SIF format),


### PR DESCRIPTION
The new container images use the new client configuration package that doesn't make use of the CVMFS config repo anymore.