### PR TITLE
add placeholder page on GPU support in EESSI

### DIFF
--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -1,0 +1,9 @@
+# GPU support
+
+!!! warning
+    **The support for GPU software in EESSI is a work-in-progess.**
+
+More information on the actions that must be performed to ensure that GPU software included in EESSI
+can use the GPU in your system will be available here soon.
+
+For now, [please open a support issue](support.md) if you need help or have questions regarding GPU support.


### PR DESCRIPTION
I'm deliberately not linking this from the menu yet, but people playing with GPU support in EESSI may be hitting references to https://eessi.io/docs/gpu once the Lmod hook included in https://github.com/EESSI/software-layer/pull/381 will be deployed...