### PR TITLE
fix subsection title in contribution policy: "Freely redistributable software"

### DIFF
--- a/docs/adding_software/contribution_policy.md
+++ b/docs/adding_software/contribution_policy.md
@@ -21,7 +21,7 @@ Note that additional restrictions may apply in specific cases that are currently
 
 ---
 
-### i) Open source software { #open_source_software }
+### i) Freely redistributable software { #freely_redistributable_software }
 
 Only **freely redistributable software** can be added to the EESSI repository,
 and we strongly prefer including only **open source software** in EESSI.


### PR DESCRIPTION
This doesn't require a version bump or update in changelog of policy imho, since the policy itself remains the same, it's just a misleading section title...