### PR TITLE
add link to join EESSI Slack to contact page

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -5,11 +5,9 @@ For more information:
 * visit our website [https://www.eessi.io](https://www.eessi.io)
 * consult our documentation at [https://eessi.github.io](https://eessi.github.io/docs)
 * ask for help at our [support portal](support.md)
+* [join our Slack channel](https://join.slack.com/t/eessi-hpc/shared_invite/zt-1wqy0t8g6-PZJTg3Hjjm5Fm3XEOkzECg)
 * reach out to one of the [project partners](partners.md)
 * check out our GitHub repositories at [https://github.com/EESSI](https://github.com/EESSI)
 * follow us on Twitter: [https://twitter.com/eessi_hpc](https://twitter.com/eessi_hpc)
-
-A Slack channel is available for the EESSI community (an invitation is required
-to join).
 
 ![EESSI logo](img/logos/EESSI_logo_horizontal.jpg)


### PR DESCRIPTION
We're already using this link at https://www.eessi.io