### PR TITLE
Document new partition features for the EESSI test suite to exclude execution scales

### DIFF
--- a/docs/test-suite/ReFrame-configuration-file.md
+++ b/docs/test-suite/ReFrame-configuration-file.md
@@ -324,7 +324,7 @@ The most common configuration items defined at this level are:
   However, since the CPU-based tests will not ask your batch scheduler for GPU resources, this _may_ fail on batch
   systems that force you to ask for at least one GPU on GPU-based nodes. Also, running CPU-only code on a GPU node is
   typically considered bad practice, thus testing its functionality is typically not relevant.
-  The `list(SCALES.keys()` adds all the scales that are valid on this system to the `features` list. These scales are
+  The `list(SCALES.keys()` adds all the scales that may be used by EESSI tests to the `features` list. These scales are
   defined in
   [`eessi.testsuite.constants.SCALES`](https://github.com/EESSI/test-suite/blob/main/eessi/testsuite/constants.py)
   and define at which scales tests should be run, e.g. single core, half a node, a full node, two nodes, etc. This

--- a/docs/test-suite/ReFrame-configuration-file.md
+++ b/docs/test-suite/ReFrame-configuration-file.md
@@ -29,7 +29,6 @@ import os
 from eessi.testsuite.common_config import common_logging_config, common_eessi_init, format_perfvars, perflog_format
 from eessi.testsuite.constants import *  
 
-ma
 site_configuration = {
     'systems': [
         {

--- a/docs/test-suite/ReFrame-configuration-file.md
+++ b/docs/test-suite/ReFrame-configuration-file.md
@@ -324,7 +324,7 @@ The most common configuration items defined at this level are:
   However, since the CPU-based tests will not ask your batch scheduler for GPU resources, this _may_ fail on batch
   systems that force you to ask for at least one GPU on GPU-based nodes. Also, running CPU-only code on a GPU node is
   typically considered bad practice, thus testing its functionality is typically not relevant.
-  The `list(SCALES.keys()` adds all the scales that may be used by EESSI tests to the `features` list. These scales are
+  The `list(SCALES.keys())` adds all the scales that may be used by EESSI tests to the `features` list. These scales are
   defined in
   [`eessi.testsuite.constants.SCALES`](https://github.com/EESSI/test-suite/blob/main/eessi/testsuite/constants.py)
   and define at which scales tests should be run, e.g. single core, half a node, a full node, two nodes, etc. This


### PR DESCRIPTION
Tests are now requesting the scale as a feature (see https://github.com/EESSI/test-suite/pull/111). This allows us to exclude running particular scales by configuring this in the config file. It does mean that all scales that are _valid_ for a certain system need to be added. 

In this PR, we document how to add it, and an example use case of how/when one wants to exclude a scale.