### PR TITLE
Fix two links on debugging page

### DIFF
--- a/docs/adding_software/debugging_failed_builds.md
+++ b/docs/adding_software/debugging_failed_builds.md
@@ -135,7 +135,7 @@ export EESSI_CPU_FAMILY=$(uname -m) && export EESSI_SOFTWARE_SUBDIR_OVERRIDE=${E
 ```
 
 ## Building software with the `EESSI-install-software.sh` script
-The Automatic build and deploy [bot](../bot.md) installs software by executing the `EESSI-install-software.sh` script. The advantage is that running this script is the closest you can get to replicating the bot's behaviour - and thus the failure. The downside is that if a PR adds a lot of software, it may take quite a long time to run - even if you might already know what the problematic software package is. In that case, you might be better off following the steps under (Building software from an easystack file)[#building-software-from-an-easystack-file] or (Building an individual package)[#building-an-individual-package].
+The Automatic build and deploy [bot](../bot.md) installs software by executing the `EESSI-install-software.sh` script. The advantage is that running this script is the closest you can get to replicating the bot's behaviour - and thus the failure. The downside is that if a PR adds a lot of software, it may take quite a long time to run - even if you might already know what the problematic software package is. In that case, you might be better off following the steps under [Building software from an easystack file](#building-software-from-an-easystack-file) or [Building an individual package](#building-an-individual-package).
 
 Note that you could also combine approaches: first build everything using the `EESSI-install-software.sh` script, until you reproduce the failure. Then, start making modifications (e.g. changes to the EasyConfig, patches, etc) and trying to rebuild that package individually to test your changes.
 


### PR DESCRIPTION
See: https://www.eessi.io/docs/adding_software/debugging_failed_builds/#building-software-with-the-eessi-install-softwaresh-script.