### PR TITLE
add zen4 to overview.md

### DIFF
--- a/docs/available_software/overview.md
+++ b/docs/available_software/overview.md
@@ -8,12 +8,12 @@ This table gives an overview of all the available software in EESSI per specific
         <tr>
             <th rowspan="3">Name</th>
             <th colspan="3">aarch64</th>
-            <th colspan="5">x86_64</th>
+            <th colspan="6">x86_64</th>
         </tr>
         </tr>
             <th colspan="3"></th>
             <th colspan="1"></th>
-            <th colspan="2">amd</th>
+            <th colspan="3">amd</th>
             <th colspan="2">intel</th>
         </tr>
         <tr>
@@ -23,6 +23,7 @@ This table gives an overview of all the available software in EESSI per specific
             <th colspan="1">generic</th>
             <th colspan="1">zen2</th>
             <th colspan="1">zen3</th>
+            <th colspan="1">zen4</th>
             <th colspan="1">haswell</th>
             <th colspan="1">skylake_avx512</th>
         </tr>


### PR DESCRIPTION
When Zen4 is ready to be added to the software overview the markdown page needs some small changes.