### PR TITLE
add workflow to update overview of available software

### DIFF
--- a/.github/workflows/update_available_software.yml
+++ b/.github/workflows/update_available_software.yml
@@ -8,13 +8,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           python-version: '3.10'
           architecture: x64
 
       - name: Mount EESSI
-        uses: eessi/github-action-eessi@v3.1.0
+        uses: eessi/github-action-eessi@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           eessi_stack_version: '2023.06'
 
@@ -42,7 +42,7 @@ jobs:
           echo "json_data_changed=${json_data_changed}" >> $GITHUB_OUTPUT
 
       - name: create pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         if: steps.update_available_software.outputs.json_data_changed == 'yes'
         with:
           add-paths: docs/available_software

--- a/.github/workflows/update_available_software.yml
+++ b/.github/workflows/update_available_software.yml
@@ -1,0 +1,55 @@
+name: Update overview of available software in EESSI
+on:
+  - workflow_dispatch
+jobs:
+  update_available_software:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          architecture: x64
+
+      - name: Mount EESSI
+        uses: eessi/github-action-eessi@v3.1.0
+        with:
+          eessi_stack_version: '2023.06'
+
+      - name: update overview of available software
+        id: update_available_software
+        run: |
+          cd scripts/available_software
+
+          # install required Python packages in virtual environment
+          python -m venv venv
+          . venv/bin/activate
+          pip install -r requirements.txt
+
+          python available_software.py
+          git status
+
+          # determine whether pull request should be opened:
+          # if JSON files in docs/available_software/data have been updated, then a PR should be opened
+          json_data_changed=$((git diff --exit-code ../../docs/available_software/data > /dev/null && echo 'no') || echo 'yes')
+          if [[ ${json_data_changed} == "yes" ]]; then
+            echo "JSON files in docs/available_software/data have been changed, PR should be opened"
+          else
+            echo "JSON files in docs/available_software/data have not been changed, no need to open PR"
+          fi
+          echo "json_data_changed=${json_data_changed}" >> $GITHUB_OUTPUT
+
+      - name: create pull request
+        uses: peter-evans/create-pull-request@v6
+        if: steps.update_available_software.outputs.json_data_changed == 'yes'
+        with:
+          add-paths: docs/available_software
+          branch: update-software-overview
+          branch-suffix: timestamp
+          commit-message: update overview of available software
+          title: update overview of available software
+          body: ''
+          token: ${{ secrets.EESSIBOT_GITHUB_TOKEN }}
+          push-to-fork: EESSIbot/docs

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -17,7 +17,6 @@ import re
 import subprocess
 import sys
 import time
-from pathlib import Path
 from typing import Union, Tuple
 import numpy as np
 from mdutils.mdutils import MdUtils
@@ -35,11 +34,7 @@ EXCLUDE_CPU_TARGETS = ['x86_64/amd/zen4']
 
 def main():
     os.environ["SHELL"] = "/bin/bash"
-    current_dir = Path(__file__).resolve()
-    project_name = 'docs'
-    root_dir = next(
-        p for p in current_dir.parents if p.parts[-1] == project_name
-    )
+    root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     path_data_dir = os.path.join(root_dir, "docs/available_software/data")
 
     # Generate the JSON overviews


### PR DESCRIPTION
For now, I've only listed `workflow_dispatch` as a trigger, which essentially means that triggering the creation of a PR will only happen when someone runs the workflow via https://github.com/EESSI/docs/blob/main/.github/workflows/update_available_software.yml .

I prefer taking that approach initially, before we enable daily (or whatever) runs of this workflow to automatically get a PR opened when the overview of available software needs to be updated...

The token (available as GitHub Action environment secret in this repo as `EESSIBOT_GITHUB_TOKEN`) is currently valid until 4 Aug'24, we'll need to make sure it gets replaced regularly (out of abundance of care).

Example of a pull request that is produced by this workflow (which was tweaked to use the `boegelbot` account and target my fork @ `boegel/EESSI-docs`: https://github.com/boegel/EESSI-docs/pull/2