### PR TITLE
fix syntax error in workflow to update overview of available software

### DIFF
--- a/.github/workflows/update_available_software.yml
+++ b/.github/workflows/update_available_software.yml
@@ -1,6 +1,6 @@
 name: Update overview of available software in EESSI
 on:
-  - workflow_dispatch
+  - workflow_dispatch:
   - schedule:
     # run every 4 hours
     - cron: '0 */4 * * *'


### PR DESCRIPTION
fix for:
```
Invalid type for `on`
```