### PR TITLE
fix another syntax error in workflow to update overview of available software

### DIFF
--- a/.github/workflows/update_available_software.yml
+++ b/.github/workflows/update_available_software.yml
@@ -1,7 +1,7 @@
 name: Update overview of available software in EESSI
 on:
-  - workflow_dispatch:
-  - schedule:
+  workflow_dispatch:
+  schedule:
     # run every 4 hours
     - cron: '0 */4 * * *'
 jobs:


### PR DESCRIPTION
```
Invalid type for `on`
```