### PR TITLE
Prevent the available software CI from running on forks

### DIFF
--- a/.github/workflows/update_available_software.yml
+++ b/.github/workflows/update_available_software.yml
@@ -6,6 +6,7 @@ on:
     - cron: '0 */4 * * *'
 jobs:
   update_available_software:
+    if: github.repository_owner == 'EESSI'   # Prevent running on forks
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6


### PR DESCRIPTION
This CI just failed on my fork, and it doesn't make sense to run this on forks, so let's disable it.