### PR TITLE
Updates

### DIFF
--- a/docs/test-suite/ReFrame-configuration-file.md
+++ b/docs/test-suite/ReFrame-configuration-file.md
@@ -328,9 +328,9 @@ The most common configuration items defined at this level are:
   [`eessi.testsuite.constants.SCALES`](https://github.com/EESSI/test-suite/blob/main/eessi/testsuite/constants.py)
   and define at which scales tests should be run, e.g. single core, half a node, a full node, two nodes, etc. This
   can be used to exclude running at certain scales on systems that would not support it. E.g. some systems might not
-  support requesting multiple partial nodes, which is what the `1cpn_2_nodes` (1 core per node, on two nodes) and
-  `1cpn_4_nodes` scales do. One could exclude these by setting e.g.
-  `features: [FEATURES[CPU]] + [s for s in SCALES if s not in ['1cpn_2_nodes', '1cpn_4_nodes']]`. With this
+  support requesting multiple partial nodes, which is what the `1cpn_2nodes` (1 core per node, on two nodes) and
+  `1cpn_4nodes` scales do. One could exclude these by setting e.g.
+  `features: [FEATURES[CPU]] + [s for s in SCALES if s not in ['1cpn_2nodes', '1cpn_4nodes']]`. With this
   configuration setting, ReFrame will run all the scales listed in `eessi.testsuite.constants.SCALES _except_
   those two. In a similar way, one could exclude all multinode tests if one just has a single node available.
 - [`devices`](https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.systems.partitions.devices): This field specifies information on devices (for example) present in the partition. Device types are standardized in the EESSI test suite in the [`eessi.testsuite.constants.DEVICE_TYPES`](https://github.com/EESSI/test-suite/blob/main/eessi/testsuite/constants.py) dictionary. This is used by the EESSI test suite to determine how many of these devices it can/should use per node.

--- a/docs/test-suite/ReFrame-configuration-file.md
+++ b/docs/test-suite/ReFrame-configuration-file.md
@@ -328,9 +328,9 @@ The most common configuration items defined at this level are:
   [`eessi.testsuite.constants.SCALES`](https://github.com/EESSI/test-suite/blob/main/eessi/testsuite/constants.py)
   and define at which scales tests should be run, e.g. single core, half a node, a full node, two nodes, etc. This
   can be used to exclude running at certain scales on systems that would not support it. E.g. some systems might not
-  support requesting multiple partial nodes, which is what the `1_cpn_2_nodes` (1 core per node, on two nodes) and
-  `1_cpn_4_nodes` scales do. One could exclude these by setting e.g.
-  `features: [FEATURES[CPU]] + [s for s in SCALES if s not in ['1_cpn_2_nodes', '1_cpn_4_nodes']]`. With this
+  support requesting multiple partial nodes, which is what the `1cpn_2_nodes` (1 core per node, on two nodes) and
+  `1cpn_4_nodes` scales do. One could exclude these by setting e.g.
+  `features: [FEATURES[CPU]] + [s for s in SCALES if s not in ['1cpn_2_nodes', '1cpn_4_nodes']]`. With this
   configuration setting, ReFrame will run all the scales listed in `eessi.testsuite.constants.SCALES _except_
   those two. In a similar way, one could exclude all multinode tests if one just has a single node available.
 - [`devices`](https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.systems.partitions.devices): This field specifies information on devices (for example) present in the partition. Device types are standardized in the EESSI test suite in the [`eessi.testsuite.constants.DEVICE_TYPES`](https://github.com/EESSI/test-suite/blob/main/eessi/testsuite/constants.py) dictionary. This is used by the EESSI test suite to determine how many of these devices it can/should use per node.

--- a/docs/test-suite/available-tests.md
+++ b/docs/test-suite/available-tests.md
@@ -79,6 +79,12 @@ A test for [ESPResSo](https://espressomd.org), a software package for performing
 
 It is implemented in [`tests/apps/espresso/`](https://github.com/EESSI/test-suite/blob/main/eessi/testsuite/tests/apps/espresso).
 
+2 test cases are included:
+* P3M (ionic crystals)
+* LJ (Lennard Jones particle box)
+
+Both tests are weak scaling tests and therefore the number of particles are scaled based on the number of MPI ranks.
+
 To run this ESPResSo test, use:
 
 ```bash

--- a/docs/test-suite/usage.md
+++ b/docs/test-suite/usage.md
@@ -194,8 +194,8 @@ well as the specific test being carried out.
 | `1_core` | using 1 CPU core 1 GPU |
 | `2_cores` | using 2 CPU cores and 1 GPU |
 | `4_cores` | using 4 CPU cores and 1 GPU |
-| `1_cpn_2_nodes` | using 1 CPU core per node, 1 GPU per node, and 2 nodes |
-| `1_cpn_4_nodes` | using 1 CPU core per node, 1 GPU per node, and 4 nodes |
+| `1cpn_2_nodes` | using 1 CPU core per node, 1 GPU per node, and 2 nodes |
+| `1cpn_4_nodes` | using 1 CPU core per node, 1 GPU per node, and 4 nodes |
 | `1_8_node` | using 1/8th of a node (12.5% of available cores/GPUs, 1 at minimum) |
 | `1_4_node` | using a quarter of a node (25% of available cores/GPUs, 1 at minimum) |
 | `1_2_node` | using half of a node (50% of available cores/GPUs, 1 at minimum) |

--- a/docs/test-suite/usage.md
+++ b/docs/test-suite/usage.md
@@ -194,8 +194,8 @@ well as the specific test being carried out.
 | `1_core` | using 1 CPU core 1 GPU |
 | `2_cores` | using 2 CPU cores and 1 GPU |
 | `4_cores` | using 4 CPU cores and 1 GPU |
-| `1cpn_2_nodes` | using 1 CPU core per node, 1 GPU per node, and 2 nodes |
-| `1cpn_4_nodes` | using 1 CPU core per node, 1 GPU per node, and 4 nodes |
+| `1cpn_2nodes` | using 1 CPU core per node, 1 GPU per node, and 2 nodes |
+| `1cpn_4nodes` | using 1 CPU core per node, 1 GPU per node, and 4 nodes |
 | `1_8_node` | using 1/8th of a node (12.5% of available cores/GPUs, 1 at minimum) |
 | `1_4_node` | using a quarter of a node (25% of available cores/GPUs, 1 at minimum) |
 | `1_2_node` | using half of a node (50% of available cores/GPUs, 1 at minimum) |


### PR DESCRIPTION
* Changed tags `1_cpn_2_nodes` and `1_cpn_4_nodes` to `1cpn_2_nodes` and `1cpn_4_nodes` respectively.
* Described the ESPResSo tests in slight more detail.