### PR TITLE
run workflow to update overview of available software only twice a day

### DIFF
--- a/.github/workflows/update_available_software.yml
+++ b/.github/workflows/update_available_software.yml
@@ -2,8 +2,8 @@ name: Update overview of available software in EESSI
 on:
   workflow_dispatch:
   schedule:
-    # run every 4 hours
-    - cron: '0 */4 * * *'
+    # run twice a day (noon + midnight)
+    - cron: '0 */12 * * *'
 jobs:
   update_available_software:
     if: github.repository_owner == 'EESSI'   # Prevent running on forks


### PR DESCRIPTION
Running every 4 hours too frequently results in multiple PRs like #265 being opened that than need to be closed because another more recent PR with the same updates got merged, so let's tune it down a bit...