### PR TITLE
improve blog index page by creating excerpts in blog posts

### DIFF
--- a/docs/blog/posts/2024/05/isc24.md
+++ b/docs/blog/posts/2024/05/isc24.md
@@ -13,6 +13,7 @@ slug: isc24
 This week, we had the privilege of attending the [ISC'24](https://www.isc-hpc.com) conference in the beautiful city of Hamburg, Germany.
 This was an excellent opportunity for us to showcase [EESSI](https://eessi.io), and gain valuable insights and feedback from the HPC community.
 
+<!-- more -->
 ---
 
 ## BoF session on EESSI

--- a/docs/blog/posts/2024/06/espresso-portable-test-run.md
+++ b/docs/blog/posts/2024/06/espresso-portable-test-run.md
@@ -23,6 +23,8 @@ With the [portable test for ESPResSo](https://www.eessi.io/docs/test-suite/avail
 in the [EESSI test suite](https://www.eessi.io/docs/test-suite) we can easily evaluate the scalability of
 ESPResSo across EuroHPC systems, even if those systems have different system architectures.
 
+<!-- more -->
+
 ## Simulating Lennard-Jones fluids using ESPResSo
 
 [Lennard-Jones fluids](https://en.wikipedia.org/wiki/Lennard-Jones_potential) model interacting soft spheres with a potential that is weakly attractive at medium range and strongly repulsive at short range. Originally designed to model noble gases, this simple setup now underpins most particle-based simulations, such as ionic liquids, polymers, proteins and colloids, where strongly repulsive pairwise potentials are desirable to prevent particles from overlapping with one another. In addition, solvated systems with atomistic resolution typically have a large excess of solvent atoms compared to solute atoms, thus Lennard-Jones interactions tend to account for a large portion of the simulation time. Compared to other potentials, the Lennard-Jones interaction is inexpensive to calculate, and its limited range allows us to partition the simulation domain into arbitrarily small regions that can be distributed among many processors.

--- a/docs/blog/posts/2024/07/extrae-at-eessi.md
+++ b/docs/blog/posts/2024/07/extrae-at-eessi.md
@@ -13,6 +13,8 @@ like [Vega](https://doc.vega.izum.si) and [Karolina](https://docs.it4i.cz/karoli
 
 It is worth noting that from that date Extrae is also available in the EESSI RISC-V repository `risv.eessi.io`.
 
+<!-- more -->
+
 Extrae is a package developed at [BSC](https://www.bsc.es/es) devoted to generate [Paraver](https://tools.bsc.es/paraver) trace-files for a post-mortem analysis of applications performance. Extrae is a tool that uses different interposition mechanisms to inject probes into the target application so as to gather information regarding the application performance. It is one of the [tools](https://pop-coe.eu/partners/tools) used in the [POP3 CoE](https://pop-coe.eu/).
 
 The work to incorporate Extrae into EESSI started early in May. It took quite some time and effort but has resulted in a number of updates, improvements and bug fixes for Extrae. The following sections explain the work done describing the issues encountered and the solutions adopted.


### PR DESCRIPTION
The `<-- more -->` separator determines which part of the blog post will be shown on the blog index page (https://www.eessi.io/docs/blog), followed by a `Continue reading` link that points to the full blog post.

See also https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#adding-an-excerpt