### PR TITLE
add redirect for GPU docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ plugins:
         contributing_sw/overview.md: adding_software/overview.md
         software_layer/adding_software.md: adding_software/overview.md
         pilot.md: repositories/pilot.md
+        gpu.md: site_specific_config/gpu.md
 markdown_extensions:
   # enable adding HTML attributes and CSS classes
   - attr_list


### PR DESCRIPTION
#188 moved `docs/gpu.md` to `docs/site_specific_config/gpu.md`.

But loading CUDA gives the message

```
$ module load CUDA/12.1.1
Lmod has detected the following error: 
You requested to load CUDA  but while the module file exists, the actual software is not entirely shipped with EESSI due to licencing. You will need to install a full copy of the CUDA SDK
where EESSI can find it.
For more information on how to do this, see https://www.eessi.io/docs/gpu/.
```