### PR TITLE
Sabryr update docs

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -17,3 +17,4 @@ Below we list some sites that we are aware of that support or make available EES
 * PLEIADES cluster at University of Wuppertal
 * Azure
 * Enabled by default for Slurm clusters and Linux "workstations" created using the StackHPC [Azimuth](https://github.com/stackhpc/azimuth) platform-on-demand portal (public examples are [Cambridge Research Cloud](https://www.hpc.cam.ac.uk/cambridge-research-cloud) and [Advanced Computing Research Centre at the University of Bristol](https://github.com/ACRC/dl-azimuth-config/tree/main)).
+* [Norwegian Ai Cloud](https://www.naic.no/) - Provide a VM provisioning system with EESSI preconfigured. Users can provision VMs on local OpenStack based cloud and on commercial clouds Google and Azure

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,0 +1,19 @@
+# Sites and systems where EESSI is available
+
+Below we list some sites that we are aware of that support or make available EESSI to their users:
+
+* EMBL Heidelberg
+* VUB Brussels
+* HPC-UGent (7 systems + VSC Tier-1 Hortense)
+* EuroHPC: Vega and Karolina
+* BAZIS cluster Vrije Universiteit Amsterdam
+* ICER HPC resources at Michigan State University
+* Norwegian Research Infrastructure Services - Betzy
+* University of Groningen HPC Cluster ('Hábrók') and also on the university's centrally provided/managed Linux workplaces
+* SURF Snellius and Spider cluster, SURF Research Cloud
+* HTC (HTCondor), Institute of Theoretical Physics from the University of Münster
+* Baobab and Yggdrasil HPC clusters at University of Geneva Switzerland
+* Anunna HPC at the Wageningen University
+* PLEIADES cluster at University of Wuppertal
+* Azure
+* Enabled by default for Slurm clusters and Linux "workstations" created using the StackHPC [Azimuth](https://github.com/stackhpc/azimuth) platform-on-demand portal (public examples are [Cambridge Research Cloud](https://www.hpc.cam.ac.uk/cambridge-research-cloud) and [Advanced Computing Research Centre at the University of Bristol](https://github.com/ACRC/dl-azimuth-config/tree/main)).


### PR DESCRIPTION
I have included Norwegian Ai cloud as a site. We have an interface (https://orchestrator.naic.no/) where users can request VMs on local OpenStack based cloud, Google or on Azure. We use Terraform for the provisioning and then use Cloud init to preconfigure EESSI.  So the users get a VM with EESSI redy to use. This helps us keep a uniform setup and increase reproducibility. i.e. if a workflow developed on one VM , it will work on another 