### PR TITLE
Including Norwegian Ai cloud

### DIFF
--- a/docs/systems.md
+++ b/docs/systems.md
@@ -105,7 +105,7 @@ EESSI is supported in the ARM partition of Deucalion with plans to expand to the
 * Betzy: [General documentation](https://documentation.sigma2.no/hpc_machines/betzy.html#betzy) | [EESSI @ Betzy](https://documentation.sigma2.no/software/eessi.html)
 * Fram: [General documentation](https://documentation.sigma2.no/hpc_machines/fram.html#fram) | [EESSI @ Fram](https://documentation.sigma2.no/software/eessi.html)
 * Saga: [General documentation](https://documentation.sigma2.no/hpc_machines/saga.html#saga) | [EESSI @ Saga](https://documentation.sigma2.no/software/eessi.html)
-
+* [Norwegian Ai Cloud](https://www.naic.no/) - Provide a VM provisioning system with EESSI preconfigured. Users can provision VMs on local OpenStack based cloud and on commercial clouds Google and Azure
 
 ### Spain
 

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -105,7 +105,7 @@ EESSI is supported in the ARM partition of Deucalion with plans to expand to the
 * Betzy: [General documentation](https://documentation.sigma2.no/hpc_machines/betzy.html#betzy) | [EESSI @ Betzy](https://documentation.sigma2.no/software/eessi.html)
 * Fram: [General documentation](https://documentation.sigma2.no/hpc_machines/fram.html#fram) | [EESSI @ Fram](https://documentation.sigma2.no/software/eessi.html)
 * Saga: [General documentation](https://documentation.sigma2.no/hpc_machines/saga.html#saga) | [EESSI @ Saga](https://documentation.sigma2.no/software/eessi.html)
-* [Norwegian Ai Cloud](https://www.naic.no/) - Provide a VM provisioning system with EESSI preconfigured. Users can provision VMs on local OpenStack based cloud and on commercial clouds Google and Azure
+* [Norwegian AI Cloud](https://www.naic.no/) - Offers a provisioning system for virtual machines (VM) with preconfigured access to EESSI. Users can launch VMs on a local OpenStack-based cloud and on the commercial clouds Google and Azure.
 
 ### Spain
 


### PR DESCRIPTION
(new pull request to replace #365
 have included Norwegian Ai cloud as a site. We have an interface (https://orchestrator.naic.no/) where users can request VMs on local OpenStack based cloud, Google or on Azure. We use Terraform for the provisioning and then use Cloud init to preconfigure EESSI. So the users get a VM with EESSI redy to use. This helps us keep a uniform setup and increase reproducibility. i.e. if a workflow developed on one VM , it will work on another