### PR TITLE
exclude `x86_64/intel/sapphirerapids` for now from overview of available software 

### DIFF
--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -28,7 +28,7 @@ from natsort import natsorted
 EESSI_TOPDIR = "/cvmfs/software.eessi.io/versions/2023.06"
 
 # some CPU targets are excluded for now, because software layer is too incomplete currently
-EXCLUDE_CPU_TARGETS = ['aarch64/a64fx', 'x86_64/intel/sapphire_rapids']
+EXCLUDE_CPU_TARGETS = ['aarch64/a64fx', 'x86_64/intel/sapphire_rapids', 'x86_64/intel/sapphire_rapids']
 
 
 # --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Also left `sapphire_rapids` in the list, since the installations are not removed yet.