### PR TITLE
Properly exclude `sapphirerapids`

### DIFF
--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -28,7 +28,7 @@ from natsort import natsorted
 EESSI_TOPDIR = "/cvmfs/software.eessi.io/versions/2023.06"
 
 # some CPU targets are excluded for now, because software layer is too incomplete currently
-EXCLUDE_CPU_TARGETS = ['aarch64/a64fx', 'x86_64/intel/sapphire_rapids', 'x86_64/intel/sapphire_rapids']
+EXCLUDE_CPU_TARGETS = ['aarch64/a64fx', 'x86_64/intel/sapphire_rapids', 'x86_64/intel/sapphirerapids']
 
 
 # --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Somehow added `sapphire_rapids` again in #389 , instead of excluding `sapphirerapids`.