### PR TITLE
Add `sapphirerapids` column to software overview page

### DIFF
--- a/docs/available_software/overview.md
+++ b/docs/available_software/overview.md
@@ -26,6 +26,7 @@ This table gives an overview of all the available software in EESSI per specific
             <th colspan="1">zen4</th>
             <th colspan="1">haswell</th>
             <th colspan="1">skylake_avx512</th>
+            <th colspan="1">sapphirerapids</th>
         </tr>
     </thead>
 </table>


### PR DESCRIPTION
Not sure how they are supposed to be ordered (alphabetically or based on when they were released), but I opted for the latter and added it below `skylake`.