### PR TITLE
next attempt to exclude nvidia grace

### DIFF
--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -28,7 +28,7 @@ from natsort import natsorted
 EESSI_TOPDIR = "/cvmfs/software.eessi.io/versions/2023.06"
 
 # some CPU targets are excluded for now, because software layer is too incomplete currently
-EXCLUDE_CPU_TARGETS = ['aarch64/a64fx', 'aarch64/nvidia/grace']
+EXCLUDE_CPU_TARGETS = ['aarch64/a64fx', 'aarch64/nvidia']
 
 
 # --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Apparently, excluding `aarch64/nvidia/grace` didn't work.