### PR TITLE
Make sure that the available software script finds `aarch64/nvidia/*` CPU targets

### DIFF
--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -210,7 +210,7 @@ def targets_eessi() -> np.ndarray:
     commands = [
         f"find {EESSI_TOPDIR}/software/linux/*/* -maxdepth 0 \\( ! -name 'intel' -a ! "
         "-name 'amd' \\) -type d",
-        f'find {EESSI_TOPDIR}/software/linux/*/{{amd,intel}}/* -maxdepth 0  -type d'
+        f'find {EESSI_TOPDIR}/software/linux/*/{{amd,intel,nvidia}}/* -maxdepth 0  -type d'
     ]
     targets = np.array([])
 


### PR DESCRIPTION
```
$ find ${EESSI_TOPDIR}/software/linux/*/{amd,intel,nvidia}/* -maxdepth 0  -type d
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/cascadelake
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/sapphirerapids
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/skylake_avx512
/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/nvidia/grace
```