### PR TITLE
Follow-up PR/fix for #438, exclude `nvidia` targets in other find command

### DIFF
--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -209,7 +209,7 @@ def targets_eessi() -> np.ndarray:
 
     commands = [
         f"find {EESSI_TOPDIR}/software/linux/*/* -maxdepth 0 \\( ! -name 'intel' -a ! "
-        "-name 'amd' \\) -type d",
+        "-name 'amd' -a ! -name 'nvidia' \\) -type d",
         f'find {EESSI_TOPDIR}/software/linux/*/{{amd,intel,nvidia}}/* -maxdepth 0  -type d'
     ]
     targets = np.array([])


### PR DESCRIPTION
Overlooked that `nvidia` should have been excluded in the other `find` command in #438. It does find `aarch64/nvidia/*` now, but without this fix it will also still find `aarch64/nvidia` itself.

```
 find ${EESSI_TOPDIR}/software/linux/*/* -maxdepth 0 \( ! -name 'intel' -a ! -name 'amd' -a ! -name 'nvidia' \) -type d
/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/a64fx
/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/generic
/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/neoverse_n1
/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/neoverse_v1
/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic
```