### PR TITLE
Temporary workaround that hardcodes the list of targets in the Python code

### DIFF
--- a/docs/available_software/overview.md
+++ b/docs/available_software/overview.md
@@ -11,7 +11,8 @@ This table gives an overview of all the available software in EESSI per specific
             <th colspan="7">x86_64</th>
         </tr>
         </tr>
-            <th colspan="4"></th>
+            <th colspan="3"></th>
+            <th colspan="1">nvidia</th>
             <th colspan="1"></th>
             <th colspan="3">amd</th>
             <th colspan="3">intel</th>
@@ -20,7 +21,7 @@ This table gives an overview of all the available software in EESSI per specific
             <th colspan="1">generic</th>
             <th colspan="1">neoverse_n1</th>
             <th colspan="1">neoverse_v1</th>
-            <th colspan="1">nvidia/grace</th>
+            <th colspan="1">grace</th>
             <th colspan="1">generic</th>
             <th colspan="1">zen2</th>
             <th colspan="1">zen3</th>

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -207,15 +207,31 @@ def targets_eessi() -> np.ndarray:
         sys.stderr.write(f"ERROR: {EESSI_TOPDIR} does not exist!\n")
         sys.exit(1)
 
-    commands = [
-        f"find {EESSI_TOPDIR}/software/linux/*/* -maxdepth 0 \\( ! -name 'intel' -a ! "
-        "-name 'amd' -a ! -name 'nvidia' \\) -type d",
-        f'find {EESSI_TOPDIR}/software/linux/*/{{amd,intel,nvidia}}/* -maxdepth 0  -type d'
-    ]
-    targets = np.array([])
+    #commands = [
+    #    f"find {EESSI_TOPDIR}/software/linux/*/* -maxdepth 0 \\( ! -name 'intel' -a ! "
+    #    "-name 'amd' -a ! -name 'nvidia' \\) -type d",
+    #    f'find {EESSI_TOPDIR}/software/linux/*/{{amd,intel,nvidia}}/* -maxdepth 0  -type d'
+    #]
+    #targets = np.array([])
 
-    for command in commands:
-        targets = np.concatenate([targets, bash_command(command)])
+    #for command in commands:
+    #    targets = np.concatenate([targets, bash_command(command)])
+
+    # Temporary workaround for sorting the targets in the way we want to show them on the page.
+    # Ideally, the javascript would do this based on the header of the table.
+    targets = np.array([
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/generic",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/neoverse_n1",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/neoverse_v1",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/nvidia/grace",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/generic",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen2",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen3",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/haswell",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/skylake_avx512",
+        "/cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/sapphirerapids",
+    ])
 
     return targets
 

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -217,8 +217,10 @@ def targets_eessi() -> np.ndarray:
     #for command in commands:
     #    targets = np.concatenate([targets, bash_command(command)])
 
+    # FIXME
     # Temporary workaround for sorting the targets in the way we want to show them on the page.
     # Ideally, the javascript would do this based on the header of the table.
+    # Also see https://github.com/EESSI/docs/issues/402.
     targets = np.array([
         "/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/generic",
         "/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/neoverse_n1",

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -207,15 +207,15 @@ def targets_eessi() -> np.ndarray:
         sys.stderr.write(f"ERROR: {EESSI_TOPDIR} does not exist!\n")
         sys.exit(1)
 
-    #commands = [
-    #    f"find {EESSI_TOPDIR}/software/linux/*/* -maxdepth 0 \\( ! -name 'intel' -a ! "
-    #    "-name 'amd' -a ! -name 'nvidia' \\) -type d",
-    #    f'find {EESSI_TOPDIR}/software/linux/*/{{amd,intel,nvidia}}/* -maxdepth 0  -type d'
-    #]
-    #targets = np.array([])
+    # commands = [
+    #     f"find {EESSI_TOPDIR}/software/linux/*/* -maxdepth 0 \\( ! -name 'intel' -a ! "
+    #     "-name 'amd' -a ! -name 'nvidia' \\) -type d",
+    #     f'find {EESSI_TOPDIR}/software/linux/*/{{amd,intel,nvidia}}/* -maxdepth 0  -type d'
+    # ]
+    # targets = np.array([])
 
-    #for command in commands:
-    #    targets = np.concatenate([targets, bash_command(command)])
+    # for command in commands:
+    #     targets = np.concatenate([targets, bash_command(command)])
 
     # FIXME
     # Temporary workaround for sorting the targets in the way we want to show them on the page.


### PR DESCRIPTION
This makes sure that we get the columns ordered in the most clear way (generic first, etc), which aligns with the headers that are defined in the markdown file. It would be nice if the javascript code would match the table headers with the json data, see https://github.com/EESSI/docs/issues/402.