### PR TITLE
exclude Grace again from software overview

### DIFF
--- a/docs/available_software/overview.md
+++ b/docs/available_software/overview.md
@@ -7,11 +7,11 @@ This table gives an overview of all the available software in EESSI per specific
     <thead>
         <tr>
             <th rowspan="3">Name</th>
-            <th colspan="4">aarch64</th>
+            <th colspan="3">aarch64</th>
             <th colspan="7">x86_64</th>
         </tr>
         </tr>
-            <th colspan="4"></th>
+            <th colspan="3"></th>
             <th colspan="1"></th>
             <th colspan="3">amd</th>
             <th colspan="3">intel</th>
@@ -20,7 +20,6 @@ This table gives an overview of all the available software in EESSI per specific
             <th colspan="1">generic</th>
             <th colspan="1">neoverse_n1</th>
             <th colspan="1">neoverse_v1</th>
-            <th colspan="1">nvidia/grace</th>
             <th colspan="1">generic</th>
             <th colspan="1">zen2</th>
             <th colspan="1">zen3</th>

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -28,7 +28,7 @@ from natsort import natsorted
 EESSI_TOPDIR = "/cvmfs/software.eessi.io/versions/2023.06"
 
 # some CPU targets are excluded for now, because software layer is too incomplete currently
-EXCLUDE_CPU_TARGETS = ['aarch64/a64fx', 'x86_64/intel/cascadelake', 'x86_64/intel/icelake']
+EXCLUDE_CPU_TARGETS = ['aarch64/a64fx', 'aarch64/nvidia/grace', 'x86_64/intel/cascadelake', 'x86_64/intel/icelake']
 
 
 # --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The page is currently broken, so let's revert the changes from #436 .