### PR TITLE
Test suite apps and change in the minimum Python version 

### DIFF
--- a/docs/test-suite/available-tests.md
+++ b/docs/test-suite/available-tests.md
@@ -64,7 +64,7 @@ A test for [OSU Micro-Benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks/
 
 It is implemented in [`tests/apps/osu.py`](https://github.com/EESSI/test-suite/blob/main/eessi/testsuite/tests/apps/osu.py).
 
-To run this Osu Micro-Benchmark, use:
+To run this OSU Micro-Benchmark, use:
 
 ```bash
 reframe --run --name OSU-Micro-Benchmarks
@@ -105,4 +105,67 @@ reframe --run --name QuantumESPRESSO
 
 !!! warning
     This test requires ReFrame v4.6.0 or newer, in older versions the QuantumESPRESSO test is not included in hpctestlib!
+
+## PyTorch { #pytorch }
+
+A test for [PyTorch](https://pytorch.org/), a machine learning library based on the Torch library, used for applications such as computer vision and natural language processing, originally developed by Meta AI and now part of the Linux Foundation umbrella.
+
+This particular benchmark runs a selected torchvision model from the list:
+* VGG16
+* Resnet50
+* Resnet152
+* Densenet121
+* Mobilenet_v3_large
+on synthetic data. The test runs on both CPUs and GPUs (currently only supports CUDA).
+
+To run this PyTorch test, use:
+
+```bash
+reframe --run --name PyTorch
+```
+
+
+## CP2K { #cp2k }
+
+A test for [CP2K](https://www.cp2k.org/), a quantum chemistry and solid state physics software package that can perform atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems.
+
+This particular benchmark runs a system with a selected number of H2O molecules and compares to a final reference energy
+once equillibrium is attained. Three systems are possible based on the number of water molecules:
+* 32
+* 128
+* 512
+
+To run this CP2K test, use:
+
+```bash
+reframe --run --name CP2K
+```
+
+
+## LAMMPS { #lammps }
+
+A test for [LAMMPS](https://www.lammps.org/#gsc.tab=0), a classical molecular dynamics code with a focus on materials modeling. It's an acronym for Large-scale Atomic/Molecular Massively Parallel Simulator.
+
+This module tests the binary 'lmp' in available modules containing substring 'LAMMPS'.
+The tests come from the lammps github repository and test the LJ and Rhodo tests described
+[here](https://docs.lammps.org/Speed_bench.html).
+
+To run this LAMMPS test, use:
+
+```bash
+reframe --run --name LAMMPS
+```
+
+
+## MetalWalls { #metalwalls }
+
+A test for [MetalWalls](https://gitlab.com/ampere2/metalwalls), a molecular dynamics code dedicated to the modelling of electrochemical systems.
+
+The benchmarks consist of a set of different inputs files that vary in the number of atoms and the type of simulation performed. They can be found in the repository linked above, which is also versioned.
+
+To run this MetalWalls test, use:
+
+```bash
+reframe --run --name MetalWalls
+```
 

--- a/docs/test-suite/installation-configuration.md
+++ b/docs/test-suite/installation-configuration.md
@@ -14,7 +14,13 @@ The EESSI test suite requires
 
 ??? note "(If your system Python version is <= 3.6, click here for some tips)
 
-    * You can upgrade the python version in a virtual environment. [Link](https://docs.python.org/3/library/venv.html)
+    * You can upgrade and manage python versions using `pyenv`. [Link](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation)
+        * For installation follow the documentation in the repository using the link above.
+        * Then follow the steps to install a new Python version and further change local paths to the new Python:
+
+                pyenv install <python version number>
+                pyenv local <python version number>
+
     * You can also install a more recent version of Python on top of the GCC/GCCcore compiler.
 
 #### Installing Reframe

--- a/docs/test-suite/installation-configuration.md
+++ b/docs/test-suite/installation-configuration.md
@@ -8,9 +8,14 @@ This page covers the requirements, installation and configuration of the [EESSI 
 
 The EESSI test suite requires 
 
-* Python >= 3.6 
+* Python >= 3.7
 * [ReFrame](https://reframe-hpc.readthedocs.io) v4.3.3 (or newer)
 * [ReFrame test library (`hpctestlib`)](https://reframe-hpc.readthedocs.io/en/stable/hpctestlib.html)
+
+??? note "(If your system Python version is <= 3.6, click here for some tips)
+
+    * You can upgrade the python version in a virtual environment. [Link](https://docs.python.org/3/library/venv.html)
+    * You can also install a more recent version of Python on top of the GCC/GCCcore compiler.
 
 #### Installing Reframe
 

--- a/docs/test-suite/installation-configuration.md
+++ b/docs/test-suite/installation-configuration.md
@@ -23,6 +23,7 @@ The EESSI test suite requires
 
     * You can install a more recent version of Python on top of the GCC/GCCcore compiler.
     * You can install a ReFrame module with EasyBuild and a [ReFrame easyconfig](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/r/ReFrame) containing a more recent Python version.
+    * Don't forget to set RFM_PURGE_ENVIRONMENT=1 if you use Python from a module. The ReFrame easyconfigs already do that for you.
 
 #### Installing Reframe
 

--- a/docs/test-suite/installation-configuration.md
+++ b/docs/test-suite/installation-configuration.md
@@ -23,7 +23,7 @@ The EESSI test suite requires
 
     * You can install a more recent version of Python on top of the GCC/GCCcore compiler.
     * You can install a ReFrame module with EasyBuild and a [ReFrame easyconfig](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/r/ReFrame) containing a more recent Python version.
-    * Don't forget to set RFM_PURGE_ENVIRONMENT=1 if you use Python from a module. The ReFrame easyconfigs already do that for you.
+    * Set RFM_PURGE_ENVIRONMENT=1 if you use Python from a module. The ReFrame easyconfigs automatically do that for you.
 
 #### Installing Reframe
 

--- a/docs/test-suite/installation-configuration.md
+++ b/docs/test-suite/installation-configuration.md
@@ -12,7 +12,7 @@ The EESSI test suite requires
 * [ReFrame](https://reframe-hpc.readthedocs.io) v4.3.3 (or newer)
 * [ReFrame test library (`hpctestlib`)](https://reframe-hpc.readthedocs.io/en/stable/hpctestlib.html)
 
-??? note "(If your system Python version is <= 3.6, click here for some tips)
+??? note "(If your system Python version is lower than the minimum required version, click here for some tips)
 
     * You can upgrade and manage python versions using `pyenv`. [Link](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation)
         * For installation follow the documentation in the repository using the link above.
@@ -21,7 +21,8 @@ The EESSI test suite requires
                 pyenv install <python version number>
                 pyenv local <python version number>
 
-    * You can also install a more recent version of Python on top of the GCC/GCCcore compiler.
+    * You can install a more recent version of Python on top of the GCC/GCCcore compiler.
+    * You can install a ReFrame module with EasyBuild and a [ReFrame easyconfig](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs/r/ReFrame) containing a more recent Python version.
 
 #### Installing Reframe
 


### PR DESCRIPTION
- Added all the apps currently available via the test-suite.
- Changed minimum Python version from 3.6 to 3.7 for the test-suite Reframe.