### PR TITLE
Update `dev.eessi.io` documentation to current state

### DIFF
--- a/docs/adding_software/adding_development_software.md
+++ b/docs/adding_software/adding_development_software.md
@@ -15,7 +15,7 @@
 
 ## Adding software
 
-Using `dev.eessi.io` is similar to using EESSI's production repository `software.eessi.io`.
+Using `dev.eessi.io` is similar to using EESSI's production repository [`software.eessi.io`](../repositories/software.eessi.io.md).
 Software builds are triggered by a [bot](https://www.eessi.io/docs/bot/) listening to pull 
 requests in [GitHub repositories](https://github.com/search?q=org%3AEESSI+dev.eessi.io&type=repositories). 
 These builds require custom easyconfig and easystack files, which should be in specific directories.
@@ -38,9 +38,9 @@ dev.eessi.io-example
 
 ```
 
-!!! note *the `X.patch` and X.py` files are optional
+!!! note "*the `X.patch` and `X.py` files are optional"
 
-    These files are patch files (ending in `.patch`) or custom easyblocks (ending in`.py`).
+    These files are [patch](https://docs.easybuild.io/patch-files/?h=patch) files (ending in `.patch`) or custom [easyblocks](https://docs.easybuild.io/terminology/#easyblocks) (ending in`.py`).
     They are not strictly necessary if your development build can use already existing 
     easyblocks available through EasyBuild, and / or if nothing needs to be patched
 
@@ -64,9 +64,9 @@ pull request. This will open a staging PR in a repository visible to EESSI maint
 #### easyconfig files and `--software-commit`
 The approach to build and install software is similar to that of `software.eessi.io`. 
 It requires one or more easyconfig files. Easyconfig files used for building for `dev.eessi.io`
-do not need to be a part of an [EasyBuild release](https://github.com/easybuilders/easybuild-easyconfigs), unlike builds for 
-`software.eessi.io`. In this case, the development easyconfigs can be located under `easyconfigs/` in the `dev.eessi.io` 
-repository being used.
+do not need to be a part of an [EasyBuild release](https://github.com/easybuilders/easybuild-easyconfigs), 
+unlike builds for `software.eessi.io`. In this case, the development easyconfigs can be located under 
+`easyconfigs/` in the `dev.eessi.io` repository being used.
 
 To allow for development builds, we leverage the `--software-commit` functionality (requires [EasyBuild](https://easybuild.io/) 
 v4.9.3 or higher). This lets us build a given application from a specific commit in repository. This can also be done from a 

--- a/docs/adding_software/adding_development_software.md
+++ b/docs/adding_software/adding_development_software.md
@@ -26,19 +26,37 @@ To see this in practice, refer to the [dev.eessi.io-example GitHub repository](h
 ```
 dev.eessi.io-example
 ├── easyconfigs
-└── easystacks
+│   ├── g
+│   │   └── gh
+│   │       ├── gh.patch*
+│   │       └── gh.py*
+│   └── gh-2.67.0-software-commit.eb
+├── easystacks
+│   └── dev.eessi.io
+│       └── 2023.06
+│           └── gh-eb-5.0.0-dev.yml
+
 ```
+
+!!! note *the `X.patch` and X.py` files are optional
+
+    These files are patch files (ending in `.patch`) or custom easyblocks (ending in`.py`).
+    They are not strictly necessary if your development build can use already existing 
+    easyblocks available through EasyBuild, and / or if nothing needs to be patched
+
 
 ### Quick steps to build for `dev.eessi.io`
 
 - Obtain commit ID from GitHub or GitLab repository with source to build.
 - Fork the project's `dev.eessi.io` repository on GitHub, or checkout to a new branch if you can do so.
 - If needed, prepare an easyconfig template using `--software-commit` and add it to `easyconfigs/`
-- Add an easystack file in `easystacks/` that with the easyconfig file above, add the
+- Add an easystack file in `easystacks/` that lists the easyconfig file above, and add the
 commit ID to `software-commit` under `options`.
 - Open a PR from the fork or branch to the main branch of the application's `dev.eessi.io` GitHub repository.
-- Instruct the bot to start a build by adding a comment with `bot: build`.
-- Confirm the build worked correctly. If so, you can deploy the software by adding the label `bot:build` to the pull request.
+- Instruct the bot to start a build by adding a comment with `bot: build`. See `bot: show_config` for to see all the
+ available build nodes and bot instances.
+- Confirm the build worked correctly. If so, you can deploy the software by adding the label `bot:build` to the 
+pull request. This will open a staging PR in a repository visible to EESSI maintainers.
 - Once the staging PR is approved, the development build will become available on `dev.eessi.io` in a few minutes!
 
 ### Installation details
@@ -47,11 +65,13 @@ commit ID to `software-commit` under `options`.
 The approach to build and install software is similar to that of `software.eessi.io`. 
 It requires one or more easyconfig files. Easyconfig files used for building for `dev.eessi.io`
 do not need to be a part of an [EasyBuild release](https://github.com/easybuilders/easybuild-easyconfigs), unlike builds for 
-`software.eessi.io`. In this case, the development easyconfigs can be located under `easyconfigs/` in the `dev.eessi.io` repository being used.
+`software.eessi.io`. In this case, the development easyconfigs can be located under `easyconfigs/` in the `dev.eessi.io` 
+repository being used.
 
-To allow for development builds, we leverage the `--software-commit` functionality (requires [EasyBuild](https://easybuild.io/) v4.9.3 or higher). This lets us build a given application from
-a specific commit in repository. This can also be done from a fork, by changing the `github_account` field in the easyconfig file. 
-We've created a template for `ESPResSo` based on the standard eaasyconfig of the most recent version. The relevant fields are:
+To allow for development builds, we leverage the `--software-commit` functionality (requires [EasyBuild](https://easybuild.io/) 
+v4.9.3 or higher). This lets us build a given application from a specific commit in repository. This can also be done from a 
+fork, by changing the `github_account` field in the easyconfig file. We've created a template for `ESPResSo` based on the 
+standard eaasyconfig of the most recent version. The relevant fields are:
 
 ``` python
 easyblock = 'CMakeMake'
@@ -77,7 +97,6 @@ sources = ['%(software_commit)s.tar.gz']
 You can also make additional changes to the easyconfig file, for example, if the new functionality requires new build or
 runtime dependencies, patches, configuration options, etc. It's a good idea to try installing from a specific commit locally first,
 to at least see if everything is parsed correctly and confirm that the right sources are being downloaded.
-
 
 While the process to build for `dev.eessi.io` is similar to the one for the [production repository](../repositories/software.eessi.io.md), there 
 are a few additional details to keep in mind.
@@ -113,11 +132,11 @@ release, then include it in the `easyconfigs/` directory.
 
 #### Checksums
 
-EasyBuild's easyconfig files typically contain [checksums](https://docs.easybuild.io/writing-easyconfig-files/?h=checksums#common_easyconfig_param_sources_checksums)
- as their use is highly recommended. By default, EasyBuild will compute the checksums of sources and patch files it needs for
-  a given installation, and compare them with the values in the easyconfig file. Because builds for `dev.eessi.io` change much
-   more often, hard coded checksums become a problem, as they'd need to be updated with every new build. For this reason, we
-    recommend not including checksums in your development easyconfig files (unless you need to, for a specific reason).
+EasyBuild's easyconfig files typically contain [checksums](https://docs.easybuild.io/writing-easyconfig-files/?h=checksums#common_easyconfig_param_sources_checksums) 
+as their use is highly recommended. By default, EasyBuild will compute the checksums of sources and patch files it needs for 
+a given installation, and compare them with the values in the easyconfig file. Because builds for `dev.eessi.io` change much 
+more often, hard coded checksums become a problem, as they'd need to be updated with every new build. For this reason, we 
+recommend not including checksums in your development easyconfig files (unless you need to, for a specific reason).
 
 #### Easystack files 
 After an easyconfig file has been created and added to the `easyconfigs` subdirectory, an [easystack file](https://docs.easybuild.io/easystack-files) that picks it up
@@ -128,7 +147,8 @@ needs to be in place so that a build can be triggered.
     The easystack files must follow a naming convention and be named something
     like: `software-eb-X.Y.Z-dev.yml`, where X.Y.Z correspond to the EasyBuild
     version used to install the software. Following our example for 
-    `ESPREsSo`, it would look like: 
+    `ESPREsSo`, an easystack file that uses EasyBuild v5.1.0 would be named `ESPResSo-eb-5.1.0-dev.yml` and
+     would look like: 
     
     ```yaml
     easyconfigs:
@@ -139,17 +159,19 @@ needs to be in place so that a build can be triggered.
 
 `ESPResSo-devel-foss-2023a-software-commit.eb` would be the name of the easyconfig file added in our example step above. 
 Note the option passing the `software-commit` for the development version that should be built.
-For the sake of this example, the chosen commit actually corresponds to the [4.2.2 release of ESPResSo](https://github.com/espressomd/espresso/releases/tag/4.2.2).
+For the sake of this example, the chosen commit actually corresponds to the 
+[4.2.2 release of ESPResSo](https://github.com/espressomd/espresso/releases/tag/4.2.2).
 
 ### Triggering builds
 
 We use the [EESSI build-test-deploy bot](../bot.md) to handle software builds.
 All one needs to do is open a PR with the changes adding the easyconfig and easystack 
 files and commenting `bot: build`. This can only be done by previously authorized users. 
-The current build cluster for `dev.eessi.io` builds only for the `zen2` CPU microarchitecture, but this is likely to change.
+The current build cluster for `dev.eessi.io` builds for the AMD `zen2`, `zen4`, and ARM 
+`neoverse_n1`, and `neoverse_v1` CPU microarchitectures, but this is likely to change.
 
 Once a build is complete and the `bot:deploy` label is added, a staging PR can be merged to deploy the
-application to the `dev.eessi.io` cvmfs repository. On a system with `dev.eessi.io` mounted, then all
-that is left is to `module use /cvmfs/dev.eessi.io/versions/2023.06/modules/all` and try out the software!
+application to the `dev.eessi.io` cvmfs repository. On a system with `dev.eessi.io` mounted, and for a project named `example`,  all
+that is left is to run `module use /cvmfs/dev.eessi.io/example/versions/2023.06/modules/all` and try out the software!
 
 There is currently no initialisation script or module for `dev.eessi.io`, but this feature is coming soon.

--- a/docs/repositories/dev.eessi.io.md
+++ b/docs/repositories/dev.eessi.io.md
@@ -7,7 +7,7 @@ This way, development versions of software can easily be tested on systems where
 
 Unlike in the [software.eessi.io](software.eessi.io.md) production repository, software installations in `dev.eessi.io` are placed in an additional `project` 
 subdirectory. On a system with `dev.eessi.io` mounted, and assuming one intends to use a project named `example` access is possible with 
-`module use /cvmfs/dev.eessi.io/**example**/versions/2023.06/modules/all`. Then, all that is left is to try out the development software!
+<pre>module use /cvmfs/dev.eessi.io/<b>example</b>/versions/2023.06/modules/all</pre>. Then, all that is left is to try out the development software!
 
 For more information on adding software to `dev.eessi.io`, please consult the relevant [documentation](../adding_software/adding_development_software.md) page.
 

--- a/docs/repositories/dev.eessi.io.md
+++ b/docs/repositories/dev.eessi.io.md
@@ -2,11 +2,14 @@
 
 ## What is `dev.eessi.io`?
 
-`dev.eessi.io` is the development repository of EESSI. With it, developers can deploy pre-release builds of their software to EESSI. 
-This way, development versions of software can easily be tested on systems where the `dev.eessi.io` CernVM-FS repository is available.
+`dev.eessi.io` is the development repository of EESSI. With it, developers in the [MultiXscale CoE](https://multixscale.eu) can deploy pre-release builds of their software to EESSI.
+This way, development versions of software can easily be tested on systems where the `dev.eessi.io` CernVM-FS repository is available, or even added to CI workflows with little effor. 
 
-On a system with `dev.eessi.io` mounted access is possible with `module use /cvmfs/dev.eessi.io/versions/2023.06/modules/all`. Then, all that is left is
-try out the development software!
+Unlike in the [software.eessi.io](software.eessi.io.md) production repository, software installations in `dev.eessi.io` are placed in an additional `project` 
+subdirectory. On a system with `dev.eessi.io` mounted, and assuming one intends to use a project named `example` access is possible with 
+`module use /cvmfs/dev.eessi.io/**example**/versions/2023.06/modules/all`. Then, all that is left is to try out the development software!
+
+For more information on adding software to `dev.eessi.io`, please consult the relevant [documentation](../adding_software/adding_development_software.md) page.
 
 ## Question or problems
 


### PR DESCRIPTION
This PR updates the documentation for `dev.eessi.io` to reflect the current state of affairs.

In particular, it now should correctly mention the project subdirectories and the repository structure. It clarifies how easystack files should be named and where they need to go, and uses the `gh` installation from EESSI/dev.eessi.io-example repository as an example. I will open a related PR for that repository to clean it up and match what the documentation here says.

It also the list of CPU micro architectures that are available for the build cluster.