### PR TITLE
Fix strict mode violations in LMod Hook examples

### DIFF
--- a/docs/known_issues/eessi-2023.06.md
+++ b/docs/known_issues/eessi-2023.06.md
@@ -42,7 +42,7 @@ function fix_ud_qp_init_openmpi(t)
 end
 
 local function combined_load_hook(t)
-    if eessi_load_hook ~= nil then
+    if isDefined("eessi_load_hook") then
         eessi_load_hook(t)
     end
     fix_ud_qp_init_openmpi(t)

--- a/docs/site_specific_config/lmod_hooks.md
+++ b/docs/site_specific_config/lmod_hooks.md
@@ -135,7 +135,7 @@ local function combined_load_hook(t)
         eessi_load_hook(t)
     end
     -- Then call the architecture-independent load hook
-    if set_my_env_var_openmpi(t) ~= nil then
+    if isDefined("set_my_env_var_openmpi") then
         set_my_env_var_openmpi(t)
     end
     -- And finally the architecture-dependent load hook we just defined
@@ -166,7 +166,7 @@ local function combined_load_hook(t)
     if isDefined("eessi_load_hook") then
         eessi_load_hook(t)
     end
-    if set_my_env_var_openmpi(t) ~= nil then
+    if isDefined("set_my_env_var_openmpi") then
         set_my_env_var_openmpi(t)
     end
     set_my_second_env_var_openmpi(t)

--- a/docs/site_specific_config/lmod_hooks.md
+++ b/docs/site_specific_config/lmod_hooks.md
@@ -47,7 +47,7 @@ for the same reason that multiple hooks cannot be registered, we need to combine
 local function combined_load_hook(t)
     -- Call the EESSI load hook (if it exists)
     -- Note that if you wanted to overwrite the EESSI hooks (not recommended!), you would omit this
-    if eessi_load_hook ~= nil then
+    if isDefined("eessi_load_hook") then
         eessi_load_hook(t)
     end
     -- Call the site-specific load hook
@@ -75,7 +75,7 @@ function set_my_env_var_openmpi(t)
 end
 
 local function combined_load_hook(t)
-    if eessi_load_hook ~= nil then
+    if isDefined("eessi_load_hook") then
         eessi_load_hook(t)
     end
     set_my_env_var_openmpi(t)
@@ -131,7 +131,7 @@ Then, we combine the functions into one
 ```lua
 local function combined_load_hook(t)
     -- Call the EESSI load hook first
-    if eessi_load_hook ~= nil then
+    if isDefined("eessi_load_hook") then
         eessi_load_hook(t)
     end
     -- Then call the architecture-independent load hook
@@ -163,7 +163,7 @@ local function set_my_second_env_var_openmpi(t)
 end
 
 local function combined_load_hook(t)
-    if eessi_load_hook ~= nil then
+    if isDefined("eessi_load_hook") then
         eessi_load_hook(t)
     end
     if set_my_env_var_openmpi(t) ~= nil then


### PR DESCRIPTION
Using `if eessi_load_hook ~= nil then` triggers the `strict` check causing
>  variable 'eessi_load_hook' is not declared

`isDefined` is available since [LMod 8.3.7](https://github.com/TACC/Lmod/commit/7ebb0ad08b24cc7b2f65d07987649ba0e4e46f47), so should be fine to recommend unconditionally.
This avoids triggering the issue and is very readable.

Fixes https://github.com/EESSI/docs/issues/493

A related issue is in the example with adding architecture dependent and independent hooks. The check `if set_my_env_var_openmpi(t) ~= nil then` calls the function instead of checking for its existence. If corrected it would run into the same issue. So use `isDefined` there too