### PR TITLE
Add UPF's MARVIN II to list of systems using EESSI

### DIFF
--- a/docs/systems.md
+++ b/docs/systems.md
@@ -134,13 +134,13 @@ This is a RISC-V cluster that uses [`riscv.eessi.io`](https://www.eessi.io/docs/
 * arriesgado-hirsute: [General documentation](https://repo.hca.bsc.es/gitlab/epi-public/risc-v-software-development-vehicles/-/wikis/HCA-Nodes-and-Queues#commercial-risc-v-nodes)
 This is a RISC-V cluster that uses [`riscv.eessi.io`](https://www.eessi.io/docs/repositories/riscv.eessi.io/)
 
-#### Universitat Pompeu Fabra (UPF)
-
-* MARVIN II: [General documentation](https://www.upf.edu/web/sct-sit/tutorials) | [EESSI @ MARVIN II]https://www.upf.edu/web/sct-sit/software)
-
 #### Galicia Supercomputing Center (CESGA)
 
 * FinisTerrae III: [General documentation](https://cesga-docs.gitlab.io/ft3-user-guide/overview.html) | [EESSI @ FinisTerrae III](https://cesga-docs.gitlab.io/ft3-user-guide/compilers_and_dev_tools.html#eessi)
+
+#### Universitat Pompeu Fabra (UPF)
+
+* MARVIN II: [General documentation](https://www.upf.edu/web/sct-sit/tutorials) | [EESSI @ MARVIN II]https://www.upf.edu/web/sct-sit/software)
 
 ### Czech Republic
 

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -126,13 +126,17 @@ MareNostrum 5 is the EuroHPC JU supercomputer hosted by the [Barcelona Supercomp
 
 ### Spain
 
-#### Barcelona Supercomputing Center
+#### Barcelona Supercomputing Center (BSC)
 
 * thunder
 * arriesgado-fedora37: [General documentation](https://repo.hca.bsc.es/gitlab/epi-public/risc-v-software-development-vehicles/-/wikis/HCA-Nodes-and-Queues#commercial-risc-v-nodes)
 This is a RISC-V cluster that uses [`riscv.eessi.io`](https://www.eessi.io/docs/repositories/riscv.eessi.io/)
 * arriesgado-hirsute: [General documentation](https://repo.hca.bsc.es/gitlab/epi-public/risc-v-software-development-vehicles/-/wikis/HCA-Nodes-and-Queues#commercial-risc-v-nodes)
 This is a RISC-V cluster that uses [`riscv.eessi.io`](https://www.eessi.io/docs/repositories/riscv.eessi.io/)
+
+#### Universitat Pompeu Fabra (UPF)
+
+* MARVIN II: [General documentation](https://www.upf.edu/web/sct-sit/tutorials) | [EESSI @ MARVIN II]https://www.upf.edu/web/sct-sit/software)
 
 #### Galicia Supercomputing Center (CESGA)
 

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -140,7 +140,7 @@ This is a RISC-V cluster that uses [`riscv.eessi.io`](https://www.eessi.io/docs/
 
 #### Universitat Pompeu Fabra Barcelona (UPF)
 
-* MARVIN II: [General documentation](https://www.upf.edu/web/sct-sit/tutorials) | [EESSI @ MARVIN II]https://www.upf.edu/web/sct-sit/software)
+* MARVIN II: [General documentation](https://www.upf.edu/web/sct-sit/tutorials) | [EESSI @ MARVIN II](https://www.upf.edu/web/sct-sit/software)
 
 ### Czech Republic
 

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -138,7 +138,7 @@ This is a RISC-V cluster that uses [`riscv.eessi.io`](https://www.eessi.io/docs/
 
 * FinisTerrae III: [General documentation](https://cesga-docs.gitlab.io/ft3-user-guide/overview.html) | [EESSI @ FinisTerrae III](https://cesga-docs.gitlab.io/ft3-user-guide/compilers_and_dev_tools.html#eessi)
 
-#### Universitat Pompeu Fabra (UPF)
+#### Universitat Pompeu Fabra Barcelona (UPF)
 
 * MARVIN II: [General documentation](https://www.upf.edu/web/sct-sit/tutorials) | [EESSI @ MARVIN II]https://www.upf.edu/web/sct-sit/software)
 


### PR DESCRIPTION
This PR adds UPF Barcelona's MARVIN II system to the list of systems that make EESSI available to their users. :tada: 

I contacted the system administrators to get their approval on making this change and they agree. They also kindly agreed to look at this PR and review to see if everything is correct. Please don't merge this PR until that has happened.