### PR TITLE
List support for AMD Zen5 CPU target

### DIFF
--- a/docs/software_layer/cpu_targets.md
+++ b/docs/software_layer/cpu_targets.md
@@ -11,6 +11,7 @@ In the 2023.06 version of the EESSI repository, the following CPU microarchitect
 * `x86_64/amd/zen2`: AMD Rome
 * `x86_64/amd/zen3`: AMD Milan, Milan-X
 * `x86_64/amd/zen4`: AMD Genoa, Genoa-X, Bergamo, Siena
+* `x86_64/amd/zen5`: AMD Turin
 * `x86_64/intel/haswell`: Intel Haswell, Broadwell
 * `x86_64/intel/skylake_avx512`: Intel Skylake
 * `x86_64/intel/cascadelake`: Intel Cascade Lake, Cooper Lake


### PR DESCRIPTION
This PR just adds at line about AMD Zen 5 support in https://www.eessi.io/docs/software_layer/cpu_targets/