### PR TITLE
add note on lmod cache when loading an EESSI module

### DIFF
--- a/docs/using_eessi/setting_up_environment.md
+++ b/docs/using_eessi/setting_up_environment.md
@@ -62,6 +62,11 @@ available to use. If you would like to see what environment variables the module
         module load EESSI/2023.06
         ```
 
+        !!! Note
+            If you encounter an Lmod error (`Did not find mpath in mA`), you
+            may need to disable the Lmod cache by setting LMOD_IGNORE_CACHE=1
+            in your environment before loading the module.
+
         :clap: Your environment is now set up, you are ready to start running software provided by EESSI!
 
     2.  If you are using an Lmod with a version older than 8.6 or any other module tool utilizing `MODULEPATH` (e.g., 


### PR DESCRIPTION
```
$ module unuse $MODULEPATH
$ module use /cvmfs/software.eessi.io/init/modules
$ module load EESSI/2025.06                                                                                                                                       
Lmod has detected the following error:  Unable to load module because of error when evaluating modulefile:
     /cvmfs/software.eessi.io/init/modules/EESSI/2025.06.lua: /usr/share/lmod/lmod/libexec/ModuleA.lua:676: Did not find mpath in mA

     Please check the modulefile and especially if there is a line number specified in the above message
If you don't understand the warning or error, contact the helpdesk at hpc@vub.be 
While processing the following module(s):
    Module fullname  Module Filename
    ---------------  ---------------
    EESSI/2025.06    /cvmfs/software.eessi.io/init/modules/EESSI/2025.06.lua
```
```
$ LMOD_IGNORE_CACHE=1 module load EESSI/2025.06
Module for EESSI/2025.06 loaded successfully
```
```
$ module --version                                                                                                                                                                                 

Modules based on Lua: Version 8.7.65 2025-08-05 10:24 -06:00
    by Robert McLay mclay@tacc.utexas.edu
```