### PR TITLE
Update supported CPU/GPU targets for 2025.06

### DIFF
--- a/docs/software_layer/cpu_targets.md
+++ b/docs/software_layer/cpu_targets.md
@@ -1,6 +1,6 @@
 # CPU targets
 
-The following table lists the CPU microarchitectures that are supported by the different versions of the EESSI repository.
+The following table lists the CPU microarchitectures that are natively supported by the different versions of the EESSI repository.
 
 | CPU target                    | Description | Supported in EESSI version |
 | ----------------------------- | ----------- | -------------------------- |
@@ -13,7 +13,7 @@ The following table lists the CPU microarchitectures that are supported by the d
 | `x86_64/amd/zen2`             | AMD Rome                                                           | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
 | `x86_64/amd/zen3`             | AMD Milan, Milan-X                                                 | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
 | `x86_64/amd/zen4`             | AMD Genoa, Genoa-X, Bergamo, Siena                                 | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/amd/zen5`             | AMD Turin                                                          | <span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/amd/zen5`             | AMD Turin                                                          | <span class="software-eessi-version-202506">2025.06</span>                                                           |
 | `x86_64/intel/haswell`        | Intel Haswell, Broadwell                                           | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
 | `x86_64/intel/skylake_avx512` | Intel Skylake                                                      | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
 | `x86_64/intel/cascadelake`    | Intel Cascade Lake, Cooper Lake                                    | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
@@ -21,3 +21,9 @@ The following table lists the CPU microarchitectures that are supported by the d
 | `x86_64/intel/sapphirerapids` | Intel Sapphire Rapids, Emerald Rapids                              | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
 
 The names of these CPU targets correspond to the names used by [archspec](https://github.com/archspec/archspec).
+
+!!! info "What does native support mean?"
+    Native support means that the software has been built on, and has been optimized for, this specific CPU type.
+    That does not mean that CPUs that are not listed here are not supported:
+    EESSI's CPU autodetection scripts will simply fall back to the stack of the best matching CPU type in terms of supported CPU instructions.
+    For instance, on an Intel Broadwell CPU you will get the stack optimized for Intel Haswell, and for an AMD Zen 5 CPU you would get the Zen 4 stack in EESSI 2023.06.

--- a/docs/software_layer/cpu_targets.md
+++ b/docs/software_layer/cpu_targets.md
@@ -1,24 +1,27 @@
+{% set eessi_202306 = '<span class="software-eessi-version-202306">2023.06</span>' %}
+{% set eessi_202506 = '<span class="software-eessi-version-202506">2025.06</span>' %}
+
 # CPU targets
 
 The following table lists the CPU microarchitectures that are natively supported by the different versions of the EESSI repository.
 
-| CPU target                    | Description | Supported in EESSI version |
-| ----------------------------- | ----------- | -------------------------- |
-| `aarch64/generic`             | fallback for Arm 64-bit CPUs (like Raspberri Pi, etc.)             | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `aarch64/a64fx`               | Fujitsu A64FX                                                      | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `aarch64/neoverse_n1`         | AWS Graviton 2, Ampere Altra, ...                                  | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `aarch64/neoverse_v1`         | AWS Graviton 3                                                     | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `aarch64/nvidia/grace`        | NVIDIA Grace                                                       | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/generic`              | fallback for older Intel + AMD CPUs (like Intel Sandy Bridge, ...) | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/amd/zen2`             | AMD Rome                                                           | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/amd/zen3`             | AMD Milan, Milan-X                                                 | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/amd/zen4`             | AMD Genoa, Genoa-X, Bergamo, Siena                                 | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/amd/zen5`             | AMD Turin                                                          | <span class="software-eessi-version-202506">2025.06</span>                                                           |
-| `x86_64/intel/haswell`        | Intel Haswell, Broadwell                                           | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/intel/skylake_avx512` | Intel Skylake                                                      | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/intel/cascadelake`    | Intel Cascade Lake, Cooper Lake                                    | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/intel/icelake`        | Intel Ice Lake                                                     | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
-| `x86_64/intel/sapphirerapids` | Intel Sapphire Rapids, Emerald Rapids                              | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| CPU target                    | Description                                                        | Supported in EESSI version                            |
+| ----------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------- |
+| `aarch64/generic`             | fallback for Arm 64-bit CPUs (like Raspberri Pi, etc.)             | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `aarch64/a64fx`               | Fujitsu A64FX                                                      | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `aarch64/neoverse_n1`         | AWS Graviton 2, Ampere Altra, ...                                  | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `aarch64/neoverse_v1`         | AWS Graviton 3                                                     | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `aarch64/nvidia/grace`        | NVIDIA Grace                                                       | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/generic`              | fallback for older Intel + AMD CPUs (like Intel Sandy Bridge, ...) | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/amd/zen2`             | AMD Rome                                                           | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/amd/zen3`             | AMD Milan, Milan-X                                                 | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/amd/zen4`             | AMD Genoa, Genoa-X, Bergamo, Siena                                 | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/amd/zen5`             | AMD Turin                                                          | {{ eessi_202506 }}                            |
+| `x86_64/intel/haswell`        | Intel Haswell, Broadwell                                           | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/intel/skylake_avx512` | Intel Skylake                                                      | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/intel/cascadelake`    | Intel Cascade Lake, Cooper Lake                                    | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/intel/icelake`        | Intel Ice Lake                                                     | {{ eessi_202306 }} {{ eessi_202506 }} |
+| `x86_64/intel/sapphirerapids` | Intel Sapphire Rapids, Emerald Rapids                              | {{ eessi_202306 }} {{ eessi_202506 }} |
 
 The names of these CPU targets correspond to the names used by [archspec](https://github.com/archspec/archspec).
 

--- a/docs/software_layer/cpu_targets.md
+++ b/docs/software_layer/cpu_targets.md
@@ -1,20 +1,23 @@
 # CPU targets
 
-In the 2023.06 version of the EESSI repository, the following CPU microarchitectures are supported.
+The following table lists the CPU microarchitectures that are supported by the different versions of the EESSI repository.
 
-* `aarch64/generic`: fallback for Arm 64-bit CPUs (like Raspberri Pi, etc.)
-* `aarch64/a64fx`: Fujitsu A64FX
-* `aarch64/neoverse_n1`: AWS Graviton 2, Ampere Altra, ...
-* `aarch64/neoverse_v1`: AWS Graviton 3
-* `aarch64/nvidia/grace`: NVIDIA Grace
-* `x86_64/generic`: fallback for older Intel + AMD CPUs (like Intel Sandy Bridge, ...)
-* `x86_64/amd/zen2`: AMD Rome
-* `x86_64/amd/zen3`: AMD Milan, Milan-X
-* `x86_64/amd/zen4`: AMD Genoa, Genoa-X, Bergamo, Siena
-* `x86_64/intel/haswell`: Intel Haswell, Broadwell
-* `x86_64/intel/skylake_avx512`: Intel Skylake
-* `x86_64/intel/cascadelake`: Intel Cascade Lake, Cooper Lake
-* `x86_64/intel/icelake`: Intel Ice Lake
-* `x86_64/intel/sapphirerapids`: Intel Sapphire Rapids, Emerald Rapids
+| CPU target                    | Description | Supported in EESSI version |
+| ----------------------------- | ----------- | -------------------------- |
+| `aarch64/generic`             | fallback for Arm 64-bit CPUs (like Raspberri Pi, etc.)             | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `aarch64/a64fx`               | Fujitsu A64FX                                                      | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `aarch64/neoverse_n1`         | AWS Graviton 2, Ampere Altra, ...                                  | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `aarch64/neoverse_v1`         | AWS Graviton 3                                                     | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `aarch64/nvidia/grace`        | NVIDIA Grace                                                       | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/generic`              | fallback for older Intel + AMD CPUs (like Intel Sandy Bridge, ...) | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/amd/zen2`             | AMD Rome                                                           | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/amd/zen3`             | AMD Milan, Milan-X                                                 | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/amd/zen4`             | AMD Genoa, Genoa-X, Bergamo, Siena                                 | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/amd/zen5`             | AMD Turin                                                          | <span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/intel/haswell`        | Intel Haswell, Broadwell                                           | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/intel/skylake_avx512` | Intel Skylake                                                      | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/intel/cascadelake`    | Intel Cascade Lake, Cooper Lake                                    | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/intel/icelake`        | Intel Ice Lake                                                     | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
+| `x86_64/intel/sapphirerapids` | Intel Sapphire Rapids, Emerald Rapids                              | <span class="software-eessi-version-202306">2023.06</span><span class="software-eessi-version-202506">2025.06</span> |
 
 The names of these CPU targets correspond to the names used by [archspec](https://github.com/archspec/archspec).

--- a/docs/software_layer/cpu_targets.md
+++ b/docs/software_layer/cpu_targets.md
@@ -1,3 +1,7 @@
+---
+hide:
+  - toc
+---
 {% set eessi_202306 = '<span class="software-eessi-version-202306">2023.06</span>' %}
 {% set eessi_202506 = '<span class="software-eessi-version-202506">2025.06</span>' %}
 

--- a/docs/software_layer/gpu_targets.md
+++ b/docs/software_layer/gpu_targets.md
@@ -1,130 +1,175 @@
+---
+hide:
+  - toc
+---
+
 # GPU targets
 
 ## NVIDIA
 
-EESSI includes optimized software installations for major NVIDIA GPU CUDA Compute Capabilities 7.0, 8.0 and 9.0, for all CPU targets listed in [CPU targets](cpu_targets.md).
+Each version of EESSI includes optimized software installations for a selected range of major NVIDIA GPU CUDA Compute Capabilities,
+for all CPU targets listed in [CPU targets](cpu_targets.md).
 
-NVIDIA guarantees forwards compatibility within a major CUDA Compute Capability (i.e. a GPU with CUDA Compute Capability 8.6 can run code built for CUDA Compute Capability 8.0).
-This means that all NVIDIA GPUs with Compute Capability 7.x, 8.x and 9.x are supported (see also [here](https://developer.nvidia.com/cuda-gpus)).
+NVIDIA guarantees forward compatibility within a major CUDA Compute Capability, i.e. a GPU with CUDA Compute Capability 8.6 can run code built for CUDA Compute Capability 8.0.
+This means that a given EESSI version supports all NVIDIA GPUs with Compute Capability X.Y if the table below includes support for Compute Capability X.0.
+On the [NVIDIA website](https://developer.nvidia.com/cuda/gpus) you can find the Compute Capability of your GPU.
 
-The decision to only ship code optimized for the major GPU architectures was made to keep the amount of software builds that need to be done at a reasonable level.
-Even just building for the major CUDA Compute Capabilities for all CPU targets currently requires 39 builds (13 CPU targets times 3 GPU targets).
+The decision to only ship code optimized for the major GPU architectures was made to keep the number of software builds that need to be done at a reasonable level.
+Even just building for three major CUDA Compute Capabilities for all CPU targets supported by EESSI version 2023.06 would require 39 builds in total (13 CPU targets times 3 GPU targets).
 
 Not all builds are done natively, i.e. on a system actually containing a CPU and GPU of the type that is being built for.
 
-The table below shows an overview of the supported CPU/GPU architectures (marked with `x`).
+The table below shows an overview of the supported CPU/GPU architectures for the different EESSI versions (marked with `x`).
 The combinations marked with an '`N`' are built natively; others are built on a CPU-only system.
 
 <table>
     <thead>
         <tr>
             <th colspan=3></th>
-            <th colspan=3><div align="center">CUDA compute capability</div></th>
+            <th colspan=5><div align="center">CUDA compute capability</div></th>
         </tr>
         <tr>
             <th colspan=3><div align="center">CPU microarchitecture</div></th>
             <th>7.0</th>
             <th>8.0</th>
             <th>9.0</th>
+            <th>10.0</th>
+            <th>12.0</th>
         </tr>
     </thead>
     <tbody>
         <tr>
-            <td rowspan=4>aarch64</td>
+            <td rowspan=5>aarch64</td>
             <td colspan=2>generic</td>
-            <td>x</td>
-            <td>x</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td colspan=2>a64fx</td>
             <td>-</td>
             <td>-</td>
             <td>-</td>
+            <td>-</td>
+            <td>-</td>
         </tr>
         <tr>
             <td colspan=2>neoverse_n1</td>
-            <td>x</td>
-            <td>x</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td colspan=2>neoverse_v1</td>
-            <td>x</td>
-            <td>x</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td>nvidia</td>
             <td>grace</td>
-            <td>x</td>
-            <td>x</td>
-            <td>N</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td colspan=6></td>
+            <td colspan=8></td>
         </tr>
         <tr>
-            <td rowspan=9>x86_64</td>
+            <td rowspan=10>x86_64</td>
             <td colspan=2>generic</td>
-            <td>x</td>
-            <td>x</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td rowspan=5>intel</td>
             <td>haswell</td>
-            <td>x</td>
-            <td>x</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td>skylake_avx512</td>
-            <td>x</td>
-            <td>x</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td>cascadelake</td>
-            <td>N</td>
-            <td>x</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td>icelake</td>
-            <td>x</td>
-            <td>N</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td>sapphirerapids</td>
-            <td>x</td>
-            <td>x</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td rowspan=3>amd</td>
+            <td rowspan=4>amd</td>
             <td>zen2</td>
-            <td>x</td>
-            <td>N</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td>zen3</td>
-            <td>x</td>
-            <td>N</td>
-            <td>x</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
             <td>zen4</td>
-            <td>x</td>
-            <td>x</td>
-            <td>N</td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+        </tr>
+        <tr>
+            <td>zen5</td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: N</span></td>
         </tr>
     </tbody>
 </table>
 
-!!! info "No NIVIDIA GPU support for A64FX"
+!!! info "No NVIDIA GPU support for A64FX"
     Note that there is no NVIDIA GPU support for A64FX at the moment, as we are not aware of any systems with A64FX CPUs and NVIDIA GPUs.
 
 ## AMD

--- a/docs/software_layer/gpu_targets.md
+++ b/docs/software_layer/gpu_targets.md
@@ -19,7 +19,7 @@ This means that a given EESSI version supports all NVIDIA GPUs with Compute Capa
 On the [NVIDIA website](https://developer.nvidia.com/cuda/gpus) you can find the Compute Capability of your GPU.
 
 The decision to only ship code optimized for the major GPU architectures was made to keep the number of software builds that need to be done at a reasonable level.
-Even just building for three major CUDA Compute Capabilities for all CPU targets supported by EESSI version 2023.06 would require 39 builds in total (13 CPU targets times 3 GPU targets).
+Even just building a single application for five major CUDA Compute Capabilities for all CPU targets supported by EESSI version 2025.06 would require 75 builds in total (15 CPU targets times 5 GPU targets).
 
 Not all builds are done natively, i.e. on a system actually containing a CPU and GPU of the type that is being built for.
 

--- a/docs/software_layer/gpu_targets.md
+++ b/docs/software_layer/gpu_targets.md
@@ -43,7 +43,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
     </thead>
     <tbody>
         <tr>
-            <td><code>aarch64/generic`</code></td>
+            <td><code>aarch64/generic</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>

--- a/docs/software_layer/gpu_targets.md
+++ b/docs/software_layer/gpu_targets.md
@@ -25,11 +25,11 @@ The combinations marked with an '`N`' are built natively; others are built on a 
 <table>
     <thead>
         <tr>
-            <th colspan=3></th>
+            <th></th>
             <th colspan=5><div align="center">CUDA compute capability</div></th>
         </tr>
         <tr>
-            <th colspan=3><div align="center">CPU microarchitecture</div></th>
+            <th><div align="center">CPU microarchitecture</div></th>
             <th>7.0</th>
             <th>8.0</th>
             <th>9.0</th>
@@ -39,8 +39,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
     </thead>
     <tbody>
         <tr>
-            <td rowspan=5>aarch64</td>
-            <td colspan=2>generic</td>
+            <td><code>aarch64/generic`</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -48,7 +47,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td colspan=2>a64fx</td>
+            <td><code>aarch64/a64fx</code></td>
             <td>-</td>
             <td>-</td>
             <td>-</td>
@@ -56,7 +55,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td>-</td>
         </tr>
         <tr>
-            <td colspan=2>neoverse_n1</td>
+            <td><code>aarch64/neoverse_n1</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -64,7 +63,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td colspan=2>neoverse_v1</td>
+            <td><code>aarch64/neoverse_v1</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -72,8 +71,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td>nvidia</td>
-            <td>grace</td>
+            <td><code>aarch64/nvidia/grace</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
@@ -81,20 +79,10 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td colspan=8></td>
+            <td colspan=6></td>
         </tr>
         <tr>
-            <td rowspan=10>x86_64</td>
-            <td colspan=2>generic</td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-        </tr>
-        <tr>
-            <td rowspan=5>intel</td>
-            <td>haswell</td>
+            <td><code>x86_64/generic</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -102,7 +90,15 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td>skylake_avx512</td>
+            <td><code>x86_64/intel/haswell</code></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+        </tr>
+        <tr>
+            <td><code>x86_64/intel/skylake_avx512</code></td>
             <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -110,7 +106,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td>cascadelake</td>
+            <td><code>x86_64/intel/cascadelake</code></td>
             <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -118,7 +114,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td>icelake</td>
+            <td><code>x86_64/intel/icelake</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -126,7 +122,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td>sapphirerapids</td>
+            <td><code>x86_64/intel/sapphirerapids</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -134,8 +130,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td rowspan=4>amd</td>
-            <td>zen2</td>
+            <td><code>x86_64/amd/zen2</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -143,7 +138,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td>zen3</td>
+            <td><code>x86_64/amd/zen3</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
@@ -151,7 +146,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td>zen4</td>
+            <td><code>x86_64/amd/zen4</code></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
@@ -159,7 +154,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
         </tr>
         <tr>
-            <td>zen5</td>
+            <td><code>x86_64/amd/zen5</code></td>
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>
             <td><span class="software-eessi-version-202506">2025.06: x</span></td>

--- a/docs/software_layer/gpu_targets.md
+++ b/docs/software_layer/gpu_targets.md
@@ -2,6 +2,10 @@
 hide:
   - toc
 ---
+{% set eessi_202306_n = '<span class="software-eessi-version-202306">2023.06: N</span>' %}
+{% set eessi_202306_x = '<span class="software-eessi-version-202306">2023.06: x</span>' %}
+{% set eessi_202506_n = '<span class="software-eessi-version-202506">2025.06: N</span>' %}
+{% set eessi_202506_x = '<span class="software-eessi-version-202506">2025.06: x</span>' %}
 
 # GPU targets
 
@@ -40,11 +44,11 @@ The combinations marked with an '`N`' are built natively; others are built on a 
     <tbody>
         <tr>
             <td><code>aarch64/generic`</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>aarch64/a64fx</code></td>
@@ -56,110 +60,110 @@ The combinations marked with an '`N`' are built natively; others are built on a 
         </tr>
         <tr>
             <td><code>aarch64/neoverse_n1</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>aarch64/neoverse_v1</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>aarch64/nvidia/grace</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td colspan=6></td>
         </tr>
         <tr>
             <td><code>x86_64/generic</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/haswell</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/skylake_avx512</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/cascadelake</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/icelake</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/sapphirerapids</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/amd/zen2</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/amd/zen3</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/amd/zen4</code></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: x</span><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202306">2023.06: N</span><span class="software-eessi-version-202506">2025.06: N</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/amd/zen5</code></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: x</span></td>
-            <td><span class="software-eessi-version-202506">2025.06: N</span></td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202506_n }}</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
CPU overview:

<img width="840" height="815" alt="image" src="https://github.com/user-attachments/assets/e0c5e88d-dc37-40df-82da-c30ce712a5a5" />

GPU overview:

<img width="1061" height="848" alt="image" src="https://github.com/user-attachments/assets/cdc46173-e7fd-4b85-b543-8236d92243bf" />

Not completely happy with this one yet. Already disabled the TOC to get more space, but there's quite a lot of information in the table. Maybe we should shorten the CPU names here or stick to the same ones as on the CPU page (i.e. `x86_64/amd/zen5` instead of having different columns)?

But, anyway, I'd say it's already an improvement (currently there's no info about 2025.06 at all), so we can further improve it in follow-up PRs.