### PR TITLE
Update documentation for MUSICA

### DIFF
--- a/docs/systems.md
+++ b/docs/systems.md
@@ -121,8 +121,6 @@ Vega is the EuroHPC JU supercomputer hosted by the [Institute for Information Sc
 * VSC-5: [General documentation](https://docs.asc.ac.at/systems/vsc5.html) | [EESSI @ VSC-5](https://docs.asc.ac.at/software/eessi.html)
 * MUSICA: [General documentation](https://docs.asc.ac.at/systems/musica.html) | [EESSI @ MUSICA](https://docs.asc.ac.at/software/eessi.html)
 
-MUSICA is currently (Jan’26) in an open test phase.
-
 ### Belgium
 
 #### Ghent University


### PR DESCRIPTION
Removed note about MUSICA being in an open test phase as the system is now in production. See https://asc.ac.at/news/2026/news-records/supercomputer-musica-goes-into-operation/