### PR TITLE
add 2026.06 to CPU targets and GPU targets pages

### DIFF
--- a/docs/available_software/css/software.css
+++ b/docs/available_software/css/software.css
@@ -138,7 +138,7 @@
   border-radius: 0.8em;
   font-size: 0.8em;
   font-style: normal;
-  background-color: darkred; /* https://www.w3schools.com/cssref/css_colors.php */
+  background-color: darkgoldenrod; /* https://www.w3schools.com/cssref/css_colors.php */
   color: var(--md-primary-bg-color);
   margin-right: 0.3em;
 }

--- a/docs/available_software/css/software.css
+++ b/docs/available_software/css/software.css
@@ -131,3 +131,14 @@
   color: var(--md-primary-bg-color);
   margin-right: 0.3em;
 }
+
+.software-eessi-version-202606 {
+  display: inline-block;
+  padding: 0.15em 0.5em;
+  border-radius: 0.8em;
+  font-size: 0.8em;
+  font-style: normal;
+  background-color: darkred; /* https://www.w3schools.com/cssref/css_colors.php */
+  color: var(--md-primary-bg-color);
+  margin-right: 0.3em;
+}

--- a/docs/software_layer/cpu_targets.md
+++ b/docs/software_layer/cpu_targets.md
@@ -4,28 +4,31 @@ hide:
 ---
 {% set eessi_202306 = '<span class="software-eessi-version-202306">2023.06</span>' %}
 {% set eessi_202506 = '<span class="software-eessi-version-202506">2025.06</span>' %}
+{% set eessi_202606 = '<span class="software-eessi-version-202606">2026.06</span>' %}
 
 # CPU targets
 
 The following table lists the CPU microarchitectures that are natively supported by the different versions of the EESSI repository.
 
-| CPU target                    | Description                                                        | Supported in EESSI version                            |
-| ----------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------- |
-| `aarch64/generic`             | fallback for Arm 64-bit CPUs (like Raspberri Pi, etc.)             | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `aarch64/a64fx`               | Fujitsu A64FX                                                      | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `aarch64/neoverse_n1`         | AWS Graviton 2, Ampere Altra, ...                                  | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `aarch64/neoverse_v1`         | AWS Graviton 3                                                     | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `aarch64/nvidia/grace`        | NVIDIA Grace                                                       | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/generic`              | fallback for older Intel + AMD CPUs (like Intel Sandy Bridge, ...) | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/amd/zen2`             | AMD Rome                                                           | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/amd/zen3`             | AMD Milan, Milan-X                                                 | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/amd/zen4`             | AMD Genoa, Genoa-X, Bergamo, Siena                                 | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/amd/zen5`             | AMD Turin                                                          | {{ eessi_202506 }}                            |
-| `x86_64/intel/haswell`        | Intel Haswell, Broadwell                                           | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/intel/skylake_avx512` | Intel Skylake                                                      | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/intel/cascadelake`    | Intel Cascade Lake, Cooper Lake                                    | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/intel/icelake`        | Intel Ice Lake                                                     | {{ eessi_202306 }} {{ eessi_202506 }} |
-| `x86_64/intel/sapphirerapids` | Intel Sapphire Rapids, Emerald Rapids                              | {{ eessi_202306 }} {{ eessi_202506 }} |
+| CPU target                    | Description                                                        | Supported in EESSI version                               |
+| ----------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------- |
+| `aarch64/generic`             | fallback for 64-bit Arm CPUs (like Raspberri Pi, etc.)             | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `aarch64/a64fx`               | Fujitsu A64FX                                                      | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `aarch64/aws/graviton4`       | AWS Graviton 4                                                     |                                       {{ eessi_202606 }} |
+| `aarch64/neoverse_n1`         | AWS Graviton 2, Ampere Altra, ...                                  | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `aarch64/neoverse_v1`         | AWS Graviton 3                                                     | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `aarch64/nvidia/grace`        | NVIDIA Grace                                                       | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `riscv64/generic`             | fallback for 64-bit RISC-V CPUs                                    |                                       {{ eessi_202606 }} |
+| `x86_64/generic`              | fallback for older Intel + AMD CPUs (like Intel Sandy Bridge, ...) | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/amd/zen2`             | AMD Rome                                                           | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/amd/zen3`             | AMD Milan, Milan-X                                                 | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/amd/zen4`             | AMD Genoa, Genoa-X, Bergamo, Siena                                 | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/amd/zen5`             | AMD Turin                                                          |                    {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/intel/haswell`        | Intel Haswell, Broadwell                                           | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/intel/skylake_avx512` | Intel Skylake                                                      | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/intel/cascadelake`    | Intel Cascade Lake, Cooper Lake                                    | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/intel/icelake`        | Intel Ice Lake                                                     | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
+| `x86_64/intel/sapphirerapids` | Intel Sapphire Rapids, Emerald Rapids                              | {{ eessi_202306 }} {{ eessi_202506 }} {{ eessi_202606 }} |
 
 The names of these CPU targets correspond to the names used by [archspec](https://github.com/archspec/archspec).
 

--- a/docs/software_layer/gpu_targets.md
+++ b/docs/software_layer/gpu_targets.md
@@ -172,7 +172,7 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td><code>x86_64/amd/zen2</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
             <td>{{ eessi_202606_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }} {{ eessi_202606_n }}</td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
             <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
             <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>

--- a/docs/software_layer/gpu_targets.md
+++ b/docs/software_layer/gpu_targets.md
@@ -6,6 +6,8 @@ hide:
 {% set eessi_202306_x = '<span class="software-eessi-version-202306">2023.06: x</span>' %}
 {% set eessi_202506_n = '<span class="software-eessi-version-202506">2025.06: N</span>' %}
 {% set eessi_202506_x = '<span class="software-eessi-version-202506">2025.06: x</span>' %}
+{% set eessi_202606_n = '<span class="software-eessi-version-202606">2026.06: N</span>' %}
+{% set eessi_202606_x = '<span class="software-eessi-version-202606">2026.06: x</span>' %}
 
 # GPU targets
 
@@ -30,11 +32,12 @@ The combinations marked with an '`N`' are built natively; others are built on a 
     <thead>
         <tr>
             <th></th>
-            <th colspan=5><div align="center">CUDA compute capability</div></th>
+            <th colspan=6><div align="center">CUDA compute capability</div></th>
         </tr>
         <tr>
             <th><div align="center">CPU microarchitecture</div></th>
             <th>7.0</th>
+            <th>7.5</th>
             <th>8.0</th>
             <th>9.0</th>
             <th>10.0</th>
@@ -45,10 +48,11 @@ The combinations marked with an '`N`' are built natively; others are built on a 
         <tr>
             <td><code>aarch64/generic</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>aarch64/a64fx</code></td>
@@ -57,113 +61,148 @@ The combinations marked with an '`N`' are built natively; others are built on a 
             <td>-</td>
             <td>-</td>
             <td>-</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td><code>aarch64/aws/graviton4</code></td>
+            <td>-</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>aarch64/neoverse_n1</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>aarch64/neoverse_v1</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>aarch64/nvidia/grace</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }} {{ eessi_202606_n }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
-            <td colspan=6></td>
+            <td colspan=7></td>
+        </tr>
+        <tr>
+            <td><code>riscv64/generic</code></td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+            <td>-</td>
+        </tr>
+        <tr>
+            <td colspan=7></td>
         </tr>
         <tr>
             <td><code>x86_64/generic</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/haswell</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/skylake_avx512</code></td>
             <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/cascadelake</code></td>
             <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/icelake</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }} {{ eessi_202606_n }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/intel/sapphirerapids</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/amd/zen2</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/amd/zen3</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }} {{ eessi_202606_n }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/amd/zen4</code></td>
             <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_x }} {{ eessi_202506_x }}</td>
-            <td>{{ eessi_202306_n }} {{ eessi_202506_n }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_x }} {{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202306_n }} {{ eessi_202506_n }} {{ eessi_202606_n }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
         </tr>
         <tr>
             <td><code>x86_64/amd/zen5</code></td>
             <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_x }}</td>
-            <td>{{ eessi_202506_n }}</td>
+            <td>{{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_x }} {{ eessi_202606_x }}</td>
+            <td>{{ eessi_202506_n }} {{ eessi_202606_n }}</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION

<img width="1098" height="851" alt="image" src="https://github.com/user-attachments/assets/91ca5d9f-f745-4c3f-a8cd-c7adf37b02ca" />


<img width="1098" height="851" alt="image" src="https://github.com/user-attachments/assets/8b1039fc-dde4-479e-961b-7ef9169113e4" />
