### PR TITLE
Easystacks for `dev.eessi.io` should be placed in a `dev.eessi.io` subdirectory

### DIFF
--- a/docs/adding_software/adding_development_software.md
+++ b/docs/adding_software/adding_development_software.md
@@ -32,7 +32,7 @@ dev.eessi.io-example
 │   │       └── gh.py*
 │   └── gh-devel-software-commit.eb
 ├── easystacks
-│   └── software.eessi.io
+│   └── dev.eessi.io
 │       ├── 2023.06
 │       │   └── gh-eb-5.1.0-dev.yml
 │       └── 2025.06
@@ -45,10 +45,6 @@ dev.eessi.io-example
     These files are [patch](https://docs.easybuild.io/patch-files/?h=patch) files (ending in `.patch`) or custom [easyblocks](https://docs.easybuild.io/terminology/#easyblocks) (ending in`.py`).
     They are not strictly necessary if your development build can use already existing 
     easyblocks available through EasyBuild, and / or if nothing needs to be patched
-
-!!! note "The `software.eessi.io` subdirectory is temporary"
-
-    The name of this subdirectory should be `dev.eessi.io`, yet renaming it will cause builds to fail. This is a known bug and the situation should change once the relevant [issue](https://github.com/EESSI/dev.eessi.io-example/issues/29) is fixed.
 
 
 ### Quick steps to build for `dev.eessi.io`


### PR DESCRIPTION
Requires https://github.com/EESSI/software-layer-scripts/pull/295.

The note was already incorrect: currently these easystacks are expected to be in `easystacks/$EESSI_DEV_PROJECT_NAME`. But after https://github.com/EESSI/software-layer-scripts/pull/295 gets merged, they should be in `easystacks/dev.eessi.io`.