### PR TITLE
Update Deucalion URLs

### DIFF
--- a/docs/blog/posts/2024/06/espresso-portable-test-run.md
+++ b/docs/blog/posts/2024/06/espresso-portable-test-run.md
@@ -16,7 +16,7 @@ This allows running ESPResSo effortlessly on the EuroHPC systems where EESSI is 
 like [Vega](https://doc.vega.izum.si) and [Karolina](https://docs.it4i.cz/karolina/introduction).
 
 On 27 June 2024, an additional installation of ESPResSo v4.2.2 that is optimized for Arm A64FX processors
-was added, which enables also running ESPResSo efficiently on [Deucalion](https://docs.macc.fccn.pt/deucalion),
+was added, which enables also running ESPResSo efficiently on [Deucalion](https://docs.deucalion.acnca.pt/deucalion),
 even though EESSI is not available yet system-wide on Deucalion (see below for more details).
 
 With the [portable test for ESPResSo](https://www.eessi.io/docs/test-suite/available-tests/#espresso) that is available

--- a/docs/blog/posts/2024/06/espresso-portable-test-run.md
+++ b/docs/blog/posts/2024/06/espresso-portable-test-run.md
@@ -16,7 +16,7 @@ This allows running ESPResSo effortlessly on the EuroHPC systems where EESSI is 
 like [Vega](https://doc.vega.izum.si) and [Karolina](https://docs.it4i.cz/karolina/introduction).
 
 On 27 June 2024, an additional installation of ESPResSo v4.2.2 that is optimized for Arm A64FX processors
-was added, which enables also running ESPResSo efficiently on [Deucalion](https://docs.deucalion.acnca.pt/deucalion),
+was added, which enables also running ESPResSo efficiently on [Deucalion](https://docs.deucalion.acnca.pt/deucalion/),
 even though EESSI is not available yet system-wide on Deucalion (see below for more details).
 
 With the [portable test for ESPResSo](https://www.eessi.io/docs/test-suite/available-tests/#espresso) that is available

--- a/docs/blog/posts/2024/10/eurohpc_user_day.md
+++ b/docs/blog/posts/2024/10/eurohpc_user_day.md
@@ -112,7 +112,7 @@ including:
 
 * An on-site cluster consisting of 4 Arm-based Raspberry Pi 3B+ boards;
 * A RISC-V StarFive VisionFive 2 SBC;
-* An Arm A64FX node of the EuroHPC system [Deucalion](https://rnca.fccn.pt/en/deucalion/);
+* An Arm A64FX node of the EuroHPC system [Deucalion](https://deucalion.acnca.pt/);
 * An A100 GPU in the EuroHPC system [Vega](https://izum.si/en/vega-en);
 
 <figure markdown="span">

--- a/docs/blog/posts/2026/03/efp-webinar.md
+++ b/docs/blog/posts/2026/03/efp-webinar.md
@@ -83,7 +83,7 @@ EESSI is already available on 7 out of 9 of current [EuroHPC supercomputers](htt
 
 This includes, in alphabetical order:
 
-- [Deucalion](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#deucalion) in Portugal, hosted by [FCT](https://www.fct.pt/en) and managed by [CNCA](https://www.incd.pt/);
+- [Deucalion](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#deucalion) in Portugal, hosted by [FCT](https://www.fct.pt/en) and managed by [CNCA](https://www.deucalion.acnca.pt/);
 - [Discoverer](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#discoverer) in Bulgaria, hosted by [Sofia Tech Park](https://sofiatech.bg/en/);
 - [Karolina](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#karolina) in Czech Republic, hosted by [IT4Innovations (IT4I)](https://www.it4i.cz/en);
 - [Leonardo](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#leonardo) in Italy, hosted by [CINECA](https://www.cineca.it/en);

--- a/docs/blog/posts/2026/03/efp-webinar.md
+++ b/docs/blog/posts/2026/03/efp-webinar.md
@@ -83,7 +83,7 @@ EESSI is already available on 7 out of 9 of current [EuroHPC supercomputers](htt
 
 This includes, in alphabetical order:
 
-- [Deucalion](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#deucalion) in Portugal, hosted by [FCT](https://www.fct.pt/en) and managed by [CNCA](https://www.deucalion.acnca.pt/);
+- [Deucalion](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#deucalion) in Portugal, hosted by [FCT](https://www.fct.pt/en) and managed by [CNCA](https://deucalion.acnca.pt/);
 - [Discoverer](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#discoverer) in Bulgaria, hosted by [Sofia Tech Park](https://sofiatech.bg/en/);
 - [Karolina](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#karolina) in Czech Republic, hosted by [IT4Innovations (IT4I)](https://www.it4i.cz/en);
 - [Leonardo](https://www.eurohpc-ju.europa.eu/supercomputers/our-supercomputers_en#leonardo) in Italy, hosted by [CINECA](https://www.cineca.it/en);

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -35,11 +35,11 @@ It serves as the base for the [Federated Software Catalog](https://docs.my-euroh
 
 ### Deucalion (Portugal)
 
-Deucalion is the EuroHPC JU supercomputer hosted by the [Minho Advanced Computing Center (MACC)](https://www.macc.fccn.pt/).
+Deucalion is the EuroHPC JU supercomputer hosted by the [Foundation for Science and Technology](https://www.fct.pt/) (FCT) and operated by the [National Center for Advanced Computing](https://deucalion.acnca.pt/) (CNCA), [INESC TEC](https://www.inesctec.pt/en), and the [University of Minho](https://www.uminho.pt/).
 
 * [Website](https://deucalion.acnca.pt/)
-* [General documentation](https://docs.deucalion.macc.fccn.pt/)
-* [EESSI @ Deucalion](https://docs.deucalion.macc.fccn.pt/jobs/eessi/)
+* [General documentation](https://docs.deucalion.acnca.pt/)
+* [EESSI @ Deucalion](https://docs.deucalion.acnca.pt/jobs/eessi/)
 * [EFP Federated Software Catalog @ Deucalion](https://docs.my-eurohpc.eu/software-catalog/system-specific/deucalion/)
 
 ### Discoverer (Bulgaria)


### PR DESCRIPTION
Updating Deucalion DNS names replacing old macc.fccn.pt with new one deucalion.acnca.pt.